### PR TITLE
Refactor slice 07 run configuration API

### DIFF
--- a/.github/plans/refactor/00-tracker.md
+++ b/.github/plans/refactor/00-tracker.md
@@ -1,6 +1,6 @@
 # Refactor v2 implementation tracker
 
-**Updated:** 2026-07-29
+**Updated:** 2026-08-03
 **Target:** the package structure in [`architecture-target.md`](architecture-target.md)
 **Execution rules:** [`README.md`](README.md)
 **Validation gates:** [`validation.md`](validation.md)
@@ -13,22 +13,20 @@ Older A-J plans are superseded. Do not implement workflow discriminated unions,
 ## Current baseline
 
 - Repository default branch: `master` at `8b34cf7` when the v2 work began.
-- Slice 01 implementation: `7ba3206` on `refactor-v2/01-cleanup`.
-- Active branch: `refactor-v2/02-remove-plugins`.
-- Active pull request: [#30 - Slice 02: Remove external extension/plugin machinery](https://github.com/Deltares-research/pywanda-hydra/pull/30).
-- Slice 02 implementation and local merge gates are complete; user merge approval is pending.
+- Integration branch: `refactor`, containing merged Slices 01 through 06.
+- Slice 07 is implemented locally and under review.
 
 ## Status
 
 | Slice | Plan | Branch | Depends on | Risk | Status |
 |---|---|---|---|---|---|
-| 01 | [`01-cleanup.md`](01-cleanup.md) | `refactor-v2/01-cleanup` | baseline | low | implemented at `7ba3206`; stacked prerequisite |
-| 02 | [`02-remove-plugins.md`](02-remove-plugins.md) | `refactor-v2/02-remove-plugins` | 01 | medium | in review; local merge gate passed |
-| 03 | [`03-wanda-model-access.md`](03-wanda-model-access.md) | `refactor-v2/03-wanda-model-access` | 02 | high | pending |
-| 04 | [`04-scenario-document.md`](04-scenario-document.md) | `refactor-v2/04-scenario-document` | 02 | medium | pending; may develop with 03 |
-| 05 | [`05-scenario-models.md`](05-scenario-models.md) | `refactor-v2/05-scenario-models` | 03, 04 | high | pending |
-| 06 | [`06-excel-loader.md`](06-excel-loader.md) | `refactor-v2/06-excel-loader` | 05 | medium | pending |
-| 07 | [`07-config-run-api.md`](07-config-run-api.md) | `refactor-v2/07-config-run-api` | 03, 04, 05, 06 | high | pending |
+| 01 | [`01-cleanup.md`](01-cleanup.md) | `refactor-v2/01-cleanup` | baseline | low | merged into `refactor` |
+| 02 | [`02-remove-plugins.md`](02-remove-plugins.md) | `refactor-v2/02-remove-plugins` | 01 | medium | merged into `refactor` |
+| 03 | [`03-wanda-model-access.md`](03-wanda-model-access.md) | `refactor-v2/03-wanda-model-access` | 02 | high | merged into `refactor` |
+| 04 | [`04-scenario-document.md`](04-scenario-document.md) | `refactor-v2/04-scenario-document` | 02 | medium | merged into `refactor` |
+| 05 | [`05-scenario-models.md`](05-scenario-models.md) | `refactor-v2/05-scenario-models` | 03, 04 | high | merged into `refactor` |
+| 06 | [`06-excel-loader.md`](06-excel-loader.md) | `refactor-v2/06-excel-loader` | 05 | medium | merged into `refactor` |
+| 07 | [`07-config-run-api.md`](07-config-run-api.md) | `refactor` | 03, 04, 05, 06 | high | in review; focused checks passed |
 | 08 | [`08-results-foundation.md`](08-results-foundation.md) | `refactor-v2/08-results` | 07 | high | pending |
 | 09A | [`09a-result-extraction.md`](09a-result-extraction.md) | `refactor-v2/09a-extraction` | 03, 05, 08 | high | pending |
 | 09B | [`09b-tables.md`](09b-tables.md) | `refactor-v2/09b-tables` | 09A | medium | pending; parallel window with 09C |

--- a/examples/run_from_config.py
+++ b/examples/run_from_config.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import argparse
 import faulthandler
-import json
 import logging
 import os
 import sys
@@ -17,17 +16,7 @@ from importlib.util import find_spec
 from pathlib import Path
 
 from pywandahydra.app_logging import setup_logging
-from pywandahydra.config.loader import (
-    RunMetadata,
-    apply_post_processing_overrides,
-    build_run_context,
-    load_run_config,
-    validate_run_paths,
-)
-from pywandahydra.execution.artifacts import create_run_directories
-from pywandahydra.execution.runner import run
-from pywandahydra.scenarios import load_scenarios
-from pywandahydra.wanda.validation import assert_preflight_valid
+from pywandahydra.run import execute_run, prepare_run
 
 # Enable console logging to see all pywandahydra messages, in developer mode.
 setup_logging(logging.DEBUG)
@@ -78,38 +67,10 @@ def main() -> None:
     args = parser.parse_args()
 
     config_path = args.config.expanduser().resolve()
-    cfg = load_run_config(config_path)
-    validate_run_paths(cfg, config_dir=config_path.parent)
-
-    scenario_path = cfg.scenario_file
-    if not scenario_path.is_absolute():
-        scenario_path = config_path.parent / scenario_path
-
-    scenarios = load_scenarios(path=scenario_path)
-    assert_preflight_valid(model_spec=cfg.model, scenarios=scenarios)
-    apply_post_processing_overrides(cfg, scenarios)
-    ctx = build_run_context(cfg)
-
-    run_root = Path(ctx.root_dir)
-    create_run_directories(ctx, config_path=config_path, scenario_file=scenario_path)
-    run_metadata = RunMetadata()
-    metadata_path = run_root / "run_metadata.json"
-    metadata_path.write_text(
-        json.dumps(run_metadata.model_dump(), indent=2, default=str),
-        encoding="utf-8",
-    )
+    plan = prepare_run(config_path, preflight=True)
 
     try:
-        result = run(
-            model=cfg.model,
-            ctx=ctx,
-            scenarios=scenarios,
-            n_workers=cfg.execution.n_workers,
-            resume=cfg.execution.resume,
-            verbose=cfg.execution.verbose,
-            workflow_name=cfg.execution.workflow.name,
-            workflow_params=cfg.execution.workflow.params,
-        )
+        result = execute_run(plan)
 
         print(
             f"Done: {result.n_success} succeeded, {result.n_failed} failed, "
@@ -125,7 +86,7 @@ def main() -> None:
                     print(f"  {case_result.get('case_id')}: {error_message}")
 
         # Check logs
-        log_dir = Path(ctx.root_dir) / "logs"
+        log_dir = plan.run_dir / "logs"
         if log_dir.exists():
             print(f"\nLogs available at: {log_dir}")
     except Exception as e:
@@ -138,4 +99,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/src/pywandahydra/cli/commands.py
+++ b/src/pywandahydra/cli/commands.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import faulthandler
-import json
 import logging
 from pathlib import Path
 
@@ -42,99 +41,15 @@ def run(
     setup_logging(log_level)
     logger = logging.getLogger(__name__)
 
-    from ..config.loader import (
-        RunMetadata,
-        apply_post_processing_overrides,
-        build_run_context,
-        load_run_config,
-        validate_run_paths,
-    )
-    from ..execution.runner import run as run_scenarios
-    from ..scenarios.loader import load_scenario_document
-    from ..wanda.validation import assert_preflight_valid
+    from ..run import execute_run, prepare_run
 
-    # Load and validate config
     try:
-        cfg = load_run_config(config)
+        plan = prepare_run(config, workers=workers, resume=True if resume else None, preflight=True)
     except (ValueError, FileNotFoundError) as e:
-        typer.echo(f"Error loading config: {e}", err=True)
+        typer.echo(f"Invalid run configuration: {e}", err=True)
         raise typer.Exit(code=1) from None
-
-    # Apply CLI overrides
-    if workers is not None:
-        if workers < 1:
-            typer.echo("--workers must be >= 1", err=True)
-            raise typer.Exit(code=1)
-        cfg.execution.n_workers = workers
-
-    if resume:
-        cfg.execution.resume = True
-
-    # Validate runtime paths before loading scenarios/executing.
-    try:
-        validate_run_paths(cfg, config_dir=config.parent)
-    except ValueError as e:
-        typer.echo(f"Invalid runtime configuration: {e}", err=True)
-        raise typer.Exit(code=1) from None
-
-    # Load scenarios from the scenario file
-    # (validate_run_paths already resolved scenario_file against the config dir)
-    scenario_path = cfg.scenario_file
-
-    try:
-        scenario_document = load_scenario_document(scenario_path)
-        scenarios = list(scenario_document.scenarios)
-    except (ValueError, FileNotFoundError) as e:
-        typer.echo(f"Error loading scenarios: {e}", err=True)
-        raise typer.Exit(code=1) from None
-
-    try:
-        assert_preflight_valid(model_spec=cfg.model, scenarios=scenarios)
-    except ValueError as e:
-        typer.echo(str(e), err=True)
-        raise typer.Exit(code=1) from None
-
-    try:
-        apply_post_processing_overrides(cfg, scenarios)
-    except ValueError as e:
-        typer.echo(f"Invalid post_processing config: {e}", err=True)
-        raise typer.Exit(code=1) from None
-
-    logger.info(
-        "Loaded %d scenarios from %s (%d included)",
-        len(scenarios),
-        scenario_path.name,
-        sum(1 for s in scenarios if s.include),
-    )
-
-    # Build run context
-    ctx = build_run_context(cfg)
-    # Bridge analysis metadata from the scenario document onto the run context
-    # (temporary path until Slice 07's RunPlan owns it).
-    ctx.analysis_meta = scenario_document.analysis_metadata
-
-    # Write run metadata
-    from ..execution.artifacts import create_run_directories
-
-    run_root = Path(ctx.root_dir)
-    create_run_directories(ctx, config_path=config, scenario_file=scenario_path)
-    run_metadata = RunMetadata()
-    metadata_path = run_root / "run_metadata.json"
-    metadata_path.write_text(
-        json.dumps(run_metadata.model_dump(), indent=2, default=str),
-        encoding="utf-8",
-    )
-
-    # Execute
-    result = run_scenarios(
-        model=cfg.model,
-        ctx=ctx,
-        scenarios=scenarios,
-        n_workers=cfg.execution.n_workers,
-        resume=cfg.execution.resume,
-        workflow_name=cfg.execution.workflow.name,
-        workflow_params=cfg.execution.workflow.params,
-    )
+    logger.info("Prepared %d included cases", len(plan.cases))
+    result = execute_run(plan)
 
     # Summary
     typer.echo(
@@ -199,38 +114,20 @@ def validate(
     ),
 ) -> None:
     """Validate a configuration file without running anything."""
-    from ..config.loader import load_run_config, validate_run_paths
-    from ..scenarios.loader import assert_scenario_file_valid, load_scenario_document
+    from ..run import validate_run
 
     try:
-        cfg = load_run_config(config)
-        typer.echo(f"Config OK: run_id={cfg.run_id}, n_workers={cfg.execution.n_workers}")
+        plan = validate_run(config)
     except (ValueError, FileNotFoundError) as e:
         typer.echo(f"Config INVALID: {e}", err=True)
         raise typer.Exit(code=1) from None
-
-    try:
-        validate_run_paths(cfg, config_dir=config.parent)
-    except ValueError as e:
-        typer.echo(f"Runtime paths INVALID: {e}", err=True)
-        raise typer.Exit(code=1) from None
-
-    try:
-        # validate_run_paths already resolved scenario_file against the config dir.
-        assert_scenario_file_valid(cfg.scenario_file)
-    except (ValueError, FileNotFoundError) as e:
-        typer.echo(f"Scenario file INVALID: {e}", err=True)
-        raise typer.Exit(code=1) from None
-
-    try:
-        scenario_document = load_scenario_document(cfg.scenario_file)
-        scenarios = list(scenario_document.scenarios)
-        n_included = sum(1 for s in scenarios if s.include)
-        typer.echo(f"Scenarios OK: {len(scenarios)} total, {n_included} included")
-    except (ValueError, FileNotFoundError) as e:
-        typer.echo(f"Scenarios INVALID: {e}", err=True)
-        raise typer.Exit(code=1) from None
-
+    typer.echo(
+        f"Config OK: run_id={plan.configuration.run_id}, "
+        f"workers={plan.configuration.execution.workers}"
+    )
+    typer.echo(
+        f"Scenarios OK: {len(plan.scenario_document.scenarios)} total, {len(plan.cases)} included"
+    )
     typer.echo("Validation passed.")
 
 
@@ -309,4 +206,3 @@ def plot(
                 render_route_plot(spec, cache, output_dir=figures_dir, export_props=export_props)
 
     typer.echo("Plotting complete.")
-

--- a/src/pywandahydra/config/__init__.py
+++ b/src/pywandahydra/config/__init__.py
@@ -1,10 +1,10 @@
-"""Configuration package - models and loader."""
+"""Authored run configuration parsing and models."""
 
-from .loader import (
-    ExecutionConfig,
-    RunConfig,
-    RunMetadata,
-    WorkflowSpec,  # noqa: F401
-    load_run_config,
+from .loader import load_run_config
+from .models import (
+    ExecutionConfiguration,
+    ModelConfiguration,
+    OutputConfiguration,
+    RunConfiguration,
+    SimulationConfiguration,
 )
-from .models import ModelSpecification, RunContext  # noqa: F401

--- a/src/pywandahydra/config/loader.py
+++ b/src/pywandahydra/config/loader.py
@@ -1,165 +1,17 @@
-﻿"""Run configuration loader and top-level config model.
-
-Loads a run configuration from a YAML file and validates it into a
-structured Pydantic model. The config defines model specification,
-execution settings, and scenario source paths.
-"""
+﻿"""Load authored run configuration files."""
 
 from __future__ import annotations
 
-import hashlib
 import json
-import os
-import platform
-import socket
-import sys
-from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import ValidationError
 
-from ..scenarios import ScenarioSpecification
-from .models import ModelSpecification, RunContext
-
-# ---------------------------------------------------------------------------
-# Execution settings
-# ---------------------------------------------------------------------------
+from .models import RunConfiguration
 
 
-class WorkflowSpec(BaseModel):
-    """Config wrapper for workflow name + validated parameter dict."""
-
-    model_config = ConfigDict(extra="forbid")
-    name: str = "default"
-    params: dict[str, Any] = Field(default_factory=dict)
-
-
-class ExecutionConfig(BaseModel):
-    """Execution worker configuration.
-
-    Attributes:
-        n_workers: Number of parallel workers; 1 runs sequentially, >1 uses
-            multiprocessing.
-        resume: Whether to skip already-completed cases.
-        workflow: Post-processing workflow name + params.
-        verbose: Enable detailed logging during execution (default False).
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    n_workers: int = Field(default=1, ge=1)
-    resume: bool = False
-    verbose: bool = False
-    workflow: WorkflowSpec = Field(default_factory=WorkflowSpec)
-
-    @model_validator(mode="before")
-    @classmethod
-    def _coerce_workflow_str(cls, data: Any) -> Any:
-        if isinstance(data, dict) and isinstance(data.get("workflow"), str):
-            data = dict(data)
-            data["workflow"] = {"name": data["workflow"]}
-        return data
-
-
-# ---------------------------------------------------------------------------
-# Run metadata (auto-captured)
-# ---------------------------------------------------------------------------
-
-
-class RunMetadata(BaseModel):
-    """Auto-captured run metadata for reproducibility.
-
-    Attributes:
-        timestamp: ISO UTC timestamp of the run.
-        hostname: Machine hostname.
-        os: Operating system description.
-        python_version: Python version string.
-        platform: Platform identifier.
-        pywandahydra_version: Package version.
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-    timestamp: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
-    hostname: str = Field(default_factory=socket.gethostname)
-    os: str = Field(default_factory=lambda: f"{platform.system()} {platform.release()}")
-    python_version: str = Field(default_factory=lambda: sys.version.split()[0])
-    platform: str = Field(default_factory=platform.platform)
-    pywandahydra_version: str = ""
-
-    def __init__(self, **data: Any) -> None:
-        super().__init__(**data)
-        if not self.pywandahydra_version:
-            try:
-                from pywandahydra import __version__
-
-                self.pywandahydra_version = __version__.strip()
-            except Exception:
-                self.pywandahydra_version = "unknown"
-
-
-# ---------------------------------------------------------------------------
-# Run configuration (top-level)
-# ---------------------------------------------------------------------------
-
-
-class PostProcessingRunConfig(BaseModel):
-    """Run-level post-processing overrides applied to every scenario.
-
-    Currently only ``theme`` is supported; when set, it overrides the per-scenario
-    theme for all scenarios in the run.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    theme: str | None = None
-
-
-class RunConfig(BaseModel):
-    """Top-level run configuration combining all settings.
-
-    Attributes:
-        run_id: Unique run identifier (auto-generated if not provided).
-        output_root: Root directory for run outputs.
-        description: Optional human-readable description.
-        execution: Execution mode and parallelism settings.
-        model: WANDA model specification.
-        scenario_file: Path to the scenario definition file (XLS).
-        post_processing: Run-level post-processing overrides (e.g. theme).
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    run_id: str = Field(
-        default_factory=lambda: datetime.now().strftime("%Y%m%d_%H%M%S"),
-        description="Unique run identifier.",
-    )
-    output_root: Path = Field(
-        default=Path("./runs"),
-        description="Root directory for run outputs.",
-    )
-    description: str | None = None
-
-    execution: ExecutionConfig = Field(default_factory=ExecutionConfig)
-    model: ModelSpecification
-    scenario_file: Path = Field(..., description="Path to the scenario definition file.")
-    post_processing: PostProcessingRunConfig = Field(default_factory=PostProcessingRunConfig)
-
-    @field_validator("output_root", "scenario_file", mode="before")
-    @classmethod
-    def normalize_path(cls, v: str | Path) -> Path:
-        """Normalize paths by expanding user home."""
-        return Path(str(v).strip()).expanduser()
-
-
-# ---------------------------------------------------------------------------
-# Loader
-# ---------------------------------------------------------------------------
-
-
-def load_run_config(path: Path | str) -> RunConfig:
+def load_run_config(path: Path | str) -> RunConfiguration:
     """Load and validate a run configuration from a YAML or JSON file.
 
     Args:
@@ -178,117 +30,15 @@ def load_run_config(path: Path | str) -> RunConfig:
 
     ext = path.suffix.lower()
     text = path.read_text(encoding="utf-8")
-
     if ext in (".yaml", ".yml"):
         raw = yaml.safe_load(text)
     elif ext == ".json":
         raw = json.loads(text)
     else:
         raise ValueError(f"Unsupported config format: '{ext}'. Use .yaml, .yml, or .json.")
-
     if not isinstance(raw, dict):
         raise ValueError(f"Config file must contain a mapping, got: {type(raw).__name__}")
-
-    return RunConfig.model_validate(raw)
-
-
-def validate_run_paths(config: RunConfig, *, config_dir: Path) -> None:
-    """Validate runtime-critical paths before executing a run.
-
-    Also resolves relative paths to absolute paths based on config_dir.
-
-    Args:
-        config: Validated run configuration.
-        config_dir: Directory that contains the run config file.
-
-    Raises:
-        ValueError: If any path is invalid or not accessible.
-    """
-    model_path = config.model.model_path
-    if not model_path.is_absolute():
-        model_path = config_dir / model_path
-
-    if model_path.suffix.lower() != ".wdi":
-        raise ValueError(f"model.model_path must point to a .wdi file, got: {model_path}")
-    if not model_path.exists():
-        raise ValueError(f"model.model_path does not exist: {model_path}")
-
-    wanda_bin = config.model.wanda_bin
-    if not wanda_bin.is_absolute():
-        wanda_bin = config_dir / wanda_bin
-    if not wanda_bin.exists() or not wanda_bin.is_dir():
-        raise ValueError(f"model.wanda_bin must be an existing directory: {wanda_bin}")
-
-    scenario_file = config.scenario_file
-    if not scenario_file.is_absolute():
-        scenario_file = config_dir / scenario_file
-    if not scenario_file.exists():
-        raise ValueError(f"scenario_file does not exist: {scenario_file}")
-
-    output_root = config.output_root
-    if not output_root.is_absolute():
-        output_root = config_dir / output_root
-    output_root.mkdir(parents=True, exist_ok=True)
-    if not os.access(output_root, os.W_OK):
-        raise ValueError(f"output_root is not writable: {output_root}")
-
-    # Update config object with absolute paths
-    config.model.model_path = model_path
-    config.model.wanda_bin = wanda_bin
-    config.scenario_file = scenario_file
-    config.output_root = output_root
-
-
-def apply_post_processing_overrides(
-    config: RunConfig, scenarios: list[ScenarioSpecification]
-) -> None:
-    """Validate run-level post-processing overrides.
-
-    Validates the theme against the registered theme registry. Application of
-    run-level output settings is deferred to the run-level plan (Slice 07);
-    for now only validation occurs so misconfigured themes still fail fast.
-    """
-    theme_name = config.post_processing.theme
-    if theme_name is None:
-        return
-
-    from ..postprocessing.plotting.theme_registry import list_themes
-
-    known = list_themes()
-    if theme_name not in known:
-        raise ValueError(
-            f"post_processing.theme '{theme_name}' is not registered. Known themes: {known}"
-        )
-
-
-def build_run_context(config: RunConfig) -> RunContext:
-    """Build a RunContext from a RunConfig.
-
-    Args:
-        config: The validated run configuration.
-
-    Returns:
-        RunContext with populated fields.
-    """
-    run_root = config.output_root / config.run_id
-    return RunContext(
-        run_id=config.run_id,
-        timestamp=datetime.now(UTC).strftime("%Y-%m-%d_%H-%M"),
-        root_dir=run_root,
-        description=config.description,
-    )
-
-
-def config_hash(config: RunConfig) -> str:
-    """Compute a deterministic hash of the run configuration.
-
-    Args:
-        config: The run configuration.
-
-    Returns:
-        Hash string prefixed with "sha256:".
-    """
-    raw = config.model_dump(mode="json")
-    serialized = json.dumps(raw, sort_keys=True, default=str)
-    return "sha256:" + hashlib.sha256(serialized.encode()).hexdigest()
-
+    try:
+        return RunConfiguration.model_validate(raw)
+    except ValidationError as exc:
+        raise ValueError(f"Invalid run configuration in {path}:\n{exc}") from None

--- a/src/pywandahydra/config/models.py
+++ b/src/pywandahydra/config/models.py
@@ -1,61 +1,26 @@
-﻿"""Configuration models for PyWANDA Hydra."""
+﻿"""Authored run-configuration models."""
 
 from __future__ import annotations
 
-from datetime import datetime
 from pathlib import Path
-from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from ..scenarios import AnalysisMeta
+
+class _AuthoredModel(BaseModel):
+    """Base model that rejects unknown authored configuration keys."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
 
-class ModelSpecification(BaseModel):
-    """Model specification and execution settings.
+class ModelConfiguration(_AuthoredModel):
+    """Authored WANDA model settings."""
 
-    Attributes
-    ----------
-    model_path : Path
-        Path to .wdi (or base path).
-    wanda_bin : Path
-        Path to WANDA binaries and executables.
-    base_model_name : str
-        Name of the wanda base model (without .wdi extension).
+    path: Path
+    wanda_bin: Path
+    upgrade: bool = False
 
-    reuse_existing_data : bool, optional
-        If a completed run or scenario model already exists, reuse it
-        instead of re-running/re-copying (default is True).
-    upgrade : bool, optional
-        Upgrade the model to the installed WANDA version on open (default is False).
-
-    run_steady : bool, optional
-        Whether to run steady simulations (default is True).
-    run_unsteady : bool, optional
-        Whether to run unsteady simulations (default is False).
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    model_path: Path = Field(..., description="Path to .wdi (or base path)")
-    wanda_bin: Path = Field(..., description="Path to WANDA binaries and executables")
-    base_model_name: str
-
-    # Run settings
-    reuse_existing_data: bool = Field(
-        default=True,
-        description="If a completed run or scenario model already exists, reuse it.",
-    )
-    upgrade: bool = Field(
-        default=False,
-        description="Upgrade the model to the installed WANDA version on open.",
-    )
-
-    # Optional execution settings you may want centrally:
-    run_steady: bool = True
-    run_unsteady: bool = False
-
-    @field_validator("model_path", mode="before")
+    @field_validator("path", mode="before")
     @classmethod
     def normalize_paths(cls, v: str | Path) -> Path:
         """Normalize paths by expanding user and stripping whitespace.
@@ -72,7 +37,6 @@ class ModelSpecification(BaseModel):
         """
         return Path(str(v).strip()).expanduser()
 
-    # Ensure wanda_bin ends with "**\\"
     @field_validator("wanda_bin", mode="before")
     @classmethod
     def ensure_wanda_bin_format(cls, v: str | Path) -> Path:
@@ -90,117 +54,42 @@ class ModelSpecification(BaseModel):
         """
         return Path(str(v).strip()).expanduser()
 
-    # Ensure base_model_name has no WANDA file suffixes (e.g., .wdi, .wdo, .wdx).
-    @field_validator("base_model_name", mode="before")
+
+class SimulationConfiguration(_AuthoredModel):
+    """Authored simulation switches."""
+
+    steady: bool = True
+    unsteady: bool = False
+
+
+class ExecutionConfiguration(_AuthoredModel):
+    """Authored execution settings."""
+
+    workers: int = Field(default=1, ge=1)
+    resume: bool = False
+
+
+class OutputConfiguration(_AuthoredModel):
+    """Authored output settings."""
+
+    theme: str | None = None
+    figure_formats: tuple[str, ...] = ()
+    table_formats: tuple[str, ...] = ()
+
+
+class RunConfiguration(_AuthoredModel):
+    """Complete user-authored run configuration."""
+
+    run_id: str
+    output_root: Path = Path("./runs")
+    description: str | None = None
+    scenario_file: Path
+    model: ModelConfiguration
+    simulation: SimulationConfiguration = Field(default_factory=SimulationConfiguration)
+    execution: ExecutionConfiguration = Field(default_factory=ExecutionConfiguration)
+    outputs: OutputConfiguration = Field(default_factory=OutputConfiguration)
+
+    @field_validator("output_root", "scenario_file", mode="before")
     @classmethod
-    def ensure_base_model_name_format(cls, v: str) -> str:
-        """Normalize base_model_name by stripping WANDA file suffixes.
-
-        Only WANDA extensions (e.g., .wdi, .wdo, .wdx) are removed; other
-        dot-segments (e.g. "model_v4.8") are preserved.
-
-        Parameters
-        ----------
-        v : str
-            The input base model name.
-
-        Returns
-        -------
-        str
-            The normalized base model name without WANDA file suffixes.
-        """
-        # Lowercase only: compared against a lowercased suffix below.
-        wanda_suffixes = {
-            ".wdi",
-            ".wdo",
-            ".wdx",
-            "._sm",
-            "._um",
-            ".__i",
-            ".__r",
-        }
-        name = Path(str(v).strip()).name
-        while (suffix := Path(name).suffix.lower()) in wanda_suffixes:
-            name = name[: -len(suffix)]
-
-        normalized = name.strip()
-        if not normalized:
-            raise ValueError("base_model_name must contain a non-empty name.")
-        return normalized
-
-
-class RunContext(BaseModel):
-    """Context information for a model run.
-
-    Attributes
-    ----------
-    run_id : str
-        Unique identifier for the run.
-    timestamp : str
-        Timestamp of the run in ISO format.
-    root_dir : Path
-        Root directory for the run.
-    analysis_meta : AnalysisMeta
-        Global analysis metadata associated with the run.
-    description : Optional[str]
-        Optional description of the run.
-    metadata : Dict[str, Any]
-        Additional metadata for the run.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    # Information about this run
-    run_id: str = Field(..., description="Unique identifier for the run.")
-    timestamp: str = Field(..., description="Timestamp of the run in ISO format.")
-    root_dir: Path = Field(..., description="Root directory for the run.")
-
-    # Global analysis metadata
-    analysis_meta: AnalysisMeta = Field(
-        default_factory=AnalysisMeta,
-        description="Global analysis metadata associated with the run.",
-    )
-
-    # Optional description and metadata
-    description: str | None = Field(default=None, description="Optional description of the run.")
-    metadata: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Additional metadata for the run.",
-    )
-
-    @field_validator("timestamp")
-    @classmethod
-    def ensure_timestamp_string(cls, v: Any) -> str:
-        """Ensure timestamp is a string in ISO format.
-
-        Parameters
-        ----------
-        v : Any
-            The input timestamp (could be datetime, str, etc.).
-
-        Returns
-        -------
-        str
-            The timestamp as a string.
-        """
-        if isinstance(v, datetime):
-            return v.isoformat()
-        return str(v).strip()
-
-    @field_validator("root_dir", mode="before")
-    @classmethod
-    def normalize_paths(cls, v: str | Path) -> Path:
-        """Normalize paths by expanding user and stripping whitespace.
-
-        Parameters
-        ----------
-        v : str | Path
-            The input path.
-
-        Returns
-        -------
-        Path
-            The normalized path.
-        """
-        return Path(str(v).strip()).expanduser()
-
+    def normalize_path(cls, value: str | Path) -> Path:
+        return Path(str(value).strip()).expanduser()

--- a/src/pywandahydra/execution/artifacts.py
+++ b/src/pywandahydra/execution/artifacts.py
@@ -7,8 +7,8 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-from ..config.models import ModelSpecification, RunContext
 from ..scenarios import ScenarioSpecification
+from .legacy import ModelSpecification, RunContext
 
 
 def create_run_directories(
@@ -79,4 +79,3 @@ def write_run_log(
     )
     with log_path.open("w", encoding="utf-8") as log_file:
         json.dump(log_data, log_file, indent=4, default=str)
-

--- a/src/pywandahydra/execution/case_plan.py
+++ b/src/pywandahydra/execution/case_plan.py
@@ -8,8 +8,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from ..config.models import ModelSpecification
 from ..scenarios import AnalysisMeta, ScenarioSpecification
+from .legacy import ModelSpecification
 
 
 @dataclass(frozen=True, slots=True)
@@ -108,4 +108,3 @@ def build_case_plans(
             )
         )
     return plans
-

--- a/src/pywandahydra/execution/legacy.py
+++ b/src/pywandahydra/execution/legacy.py
@@ -1,0 +1,36 @@
+"""Private compatibility contracts required by the pre-S12 execution engine."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..scenarios import AnalysisMeta
+
+
+class ModelSpecification(BaseModel):
+    """Legacy engine model settings, constructed only from a prepared plan."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model_path: Path
+    wanda_bin: Path
+    base_model_name: str
+    reuse_existing_data: bool = True
+    upgrade: bool = False
+    run_steady: bool = True
+    run_unsteady: bool = False
+
+
+class RunContext(BaseModel):
+    """Legacy engine run context, constructed only from a prepared plan."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    timestamp: str
+    root_dir: Path
+    analysis_meta: AnalysisMeta = Field(default_factory=AnalysisMeta)
+    description: str | None = None
+    metadata: dict[str, object] = Field(default_factory=dict)

--- a/src/pywandahydra/execution/plans.py
+++ b/src/pywandahydra/execution/plans.py
@@ -1,0 +1,23 @@
+"""Prepared execution plans and legacy-engine conversion helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..config.models import RunConfiguration
+from ..scenarios.models.document import ScenarioDocument
+from .case_plan import CasePlan
+
+
+@dataclass(frozen=True, slots=True)
+class RunPlan:
+    """Prepared, side-effect-free input for one run execution."""
+
+    configuration: RunConfiguration
+    config_path: Path
+    model_path: Path
+    wanda_bin: Path
+    run_dir: Path
+    scenario_document: ScenarioDocument
+    cases: tuple[CasePlan, ...]

--- a/src/pywandahydra/execution/runner.py
+++ b/src/pywandahydra/execution/runner.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Any
 
 from ..app_logging import setup_logging
-from ..config.models import ModelSpecification, RunContext
 from ..execution.artifacts import create_run_directories, write_run_log
 from ..execution.case_plan import CasePlan, build_case_plans
 from ..execution.journal import CaseJournal, resume_decision
@@ -23,6 +22,7 @@ from ..postprocessing.core.context import PostProcessingRunContext
 from ..postprocessing.workflows import bootstrap as bootstrap_workflows
 from ..postprocessing.workflows.base import resolve_workflow
 from ..scenarios import ScenarioSpecification
+from .legacy import ModelSpecification, RunContext
 
 logger = logging.getLogger(__name__)
 
@@ -201,4 +201,3 @@ def _run_multiprocess(
     # Sort by case_id for deterministic output ordering
     results.sort(key=lambda r: r.get("case_id", ""))
     return results
-

--- a/src/pywandahydra/run.py
+++ b/src/pywandahydra/run.py
@@ -1,0 +1,146 @@
+"""Public run preparation, validation, and execution API."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .config import ExecutionConfiguration, RunConfiguration, load_run_config
+from .execution.case_plan import build_case_plans
+from .execution.legacy import ModelSpecification
+from .execution.plans import RunPlan
+from .scenarios.loader import load_scenario_document
+from .scenarios.models.document import ScenarioDocument
+
+
+def _resolve(path: Path, base_dir: Path) -> Path:
+    return path if path.is_absolute() else (base_dir / path).resolve()
+
+
+def _validate_paths(
+    configuration: RunConfiguration, config_path: Path
+) -> tuple[Path, Path, Path, Path]:
+    base_dir = config_path.parent
+    model_path = _resolve(configuration.model.path, base_dir)
+    wanda_bin = _resolve(configuration.model.wanda_bin, base_dir)
+    scenario_path = _resolve(configuration.scenario_file, base_dir)
+    run_dir = _resolve(configuration.output_root, base_dir) / configuration.run_id
+
+    if model_path.suffix.lower() != ".wdi":
+        raise ValueError(f"model.path must point to a .wdi file, got: {model_path}")
+    if not model_path.is_file():
+        raise ValueError(f"model.path does not exist: {model_path}")
+    if not wanda_bin.is_dir():
+        raise ValueError(f"model.wanda_bin must be an existing directory: {wanda_bin}")
+    if not scenario_path.is_file():
+        raise ValueError(f"scenario_file does not exist: {scenario_path}")
+    return model_path, wanda_bin, scenario_path, run_dir
+
+
+def _legacy_model(plan: RunPlan) -> ModelSpecification:
+    return ModelSpecification(
+        model_path=plan.model_path,
+        wanda_bin=plan.wanda_bin,
+        base_model_name=plan.model_path.stem,
+        upgrade=plan.configuration.model.upgrade,
+        run_steady=plan.configuration.simulation.steady,
+        run_unsteady=plan.configuration.simulation.unsteady,
+    )
+
+
+def _validate_case_names(document: ScenarioDocument) -> None:
+    names = [scenario.name for scenario in document.scenarios if scenario.include]
+    invalid = [name for name in names if not name or Path(name).name != name or name in {".", ".."}]
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    if invalid:
+        raise ValueError(f"Included case names must be safe path names: {invalid}")
+    if duplicates:
+        raise ValueError(f"Included case names must be unique: {duplicates}")
+
+
+def prepare_run(
+    config_path: Path | str,
+    *,
+    workers: int | None = None,
+    resume: bool | None = None,
+    preflight: bool = False,
+) -> RunPlan:
+    """Load and prepare a run without creating model copies or output files."""
+    resolved_config_path = Path(config_path).expanduser().resolve()
+    configuration = load_run_config(resolved_config_path)
+    execution: ExecutionConfiguration = configuration.execution
+    if workers is not None:
+        execution = execution.model_copy(update={"workers": workers})
+    if resume is not None:
+        execution = execution.model_copy(update={"resume": resume})
+    if execution != configuration.execution:
+        configuration = configuration.model_copy(update={"execution": execution})
+
+    model_path, wanda_bin, scenario_path, run_dir = _validate_paths(
+        configuration, resolved_config_path
+    )
+    document = load_scenario_document(scenario_path)
+    _validate_case_names(document)
+    legacy_model = _legacy_model_stub(configuration, model_path, wanda_bin)
+    cases = tuple(
+        build_case_plans(
+            legacy_model,
+            list(document.scenarios),
+            run_dir,
+            analysis_metadata=document.analysis_metadata,
+        )
+    )
+    plan = RunPlan(
+        configuration=configuration,
+        config_path=resolved_config_path,
+        model_path=model_path,
+        wanda_bin=wanda_bin,
+        run_dir=run_dir,
+        scenario_document=document,
+        cases=cases,
+    )
+    if preflight:
+        from .wanda.validation import assert_preflight_valid
+
+        assert_preflight_valid(model_spec=_legacy_model(plan), scenarios=list(document.scenarios))
+    return plan
+
+
+def _legacy_model_stub(
+    configuration: RunConfiguration, model_path: Path, wanda_bin: Path
+) -> ModelSpecification:
+    return ModelSpecification(
+        model_path=model_path,
+        wanda_bin=wanda_bin,
+        base_model_name=model_path.stem,
+        upgrade=configuration.model.upgrade,
+        run_steady=configuration.simulation.steady,
+        run_unsteady=configuration.simulation.unsteady,
+    )
+
+
+def validate_run(config_path: Path | str, *, preflight: bool = False) -> RunPlan:
+    """Validate and prepare a configuration, optionally checking WANDA inputs."""
+    return prepare_run(config_path, preflight=preflight)
+
+
+def execute_run(plan: RunPlan) -> Any:
+    """Execute a prepared plan through the temporary legacy-engine bridge."""
+    from .execution.legacy import RunContext
+    from .execution.runner import run
+
+    context = RunContext(
+        run_id=plan.configuration.run_id,
+        timestamp=datetime.now(UTC).strftime("%Y-%m-%d_%H-%M"),
+        root_dir=plan.run_dir,
+        analysis_meta=plan.scenario_document.analysis_metadata,
+        description=plan.configuration.description,
+    )
+    return run(
+        model=_legacy_model(plan),
+        ctx=context,
+        scenarios=list(plan.scenario_document.scenarios),
+        n_workers=plan.configuration.execution.workers,
+        resume=plan.configuration.execution.resume,
+    )

--- a/src/pywandahydra/wanda/model_access.py
+++ b/src/pywandahydra/wanda/model_access.py
@@ -8,7 +8,7 @@ from typing import Any, Protocol, TypeAlias
 
 import numpy as np
 
-from ..config.models import ModelSpecification
+from ..execution.legacy import ModelSpecification
 from ..scenarios import ModelParameterChange
 
 ModelHandle: TypeAlias = Any
@@ -73,4 +73,3 @@ class WandaModelAccess(Protocol):
     ) -> tuple[np.ndarray, np.ndarray]: ...
 
     def get_pipe_profile_table(self, handle: Any, pipe_name: str) -> np.ndarray: ...
-

--- a/src/pywandahydra/wanda/pywanda_model_access.py
+++ b/src/pywandahydra/wanda/pywanda_model_access.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 import numpy as np
 import pywanda
 
-from ..config.models import ModelSpecification
+from ..execution.legacy import ModelSpecification
 from ..scenarios import ModelParameterChange
 from .item_lookup import get_item, resolve_items
 from .model_files import prepare_scenario_model
@@ -191,4 +191,3 @@ class PywandaModelAccess:
             item.get_property("Profile").get_table().get_float_data(),
             dtype=np.float64,
         )
-

--- a/src/pywandahydra/wanda/session.py
+++ b/src/pywandahydra/wanda/session.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pywanda
 
-from ..config.models import ModelSpecification
+from ..execution.legacy import ModelSpecification
 
 logger = logging.getLogger(__name__)
 

--- a/src/pywandahydra/wanda/validation.py
+++ b/src/pywandahydra/wanda/validation.py
@@ -9,8 +9,8 @@ from multiprocessing import get_context
 from multiprocessing.connection import Connection
 from typing import Any, cast
 
-from ..config.models import ModelSpecification
 from ..disuse import parse_disuse_value
+from ..execution.legacy import ModelSpecification
 from ..scenarios import ScenarioSpecification
 from .item_lookup import get_item, resolve_items
 from .session import wanda_session
@@ -288,4 +288,3 @@ def assert_preflight_valid(
             f"{issue.component}.{issue.property_name} -> {issue.message}"
         )
     raise PreflightValidationError("\n".join(lines))
-

--- a/tests/integration_test/conftest.py
+++ b/tests/integration_test/conftest.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from pywandahydra.config.models import ModelSpecification
+from pywandahydra.execution.legacy import ModelSpecification
 
 sys.path.insert(0, str(Path(__file__).parents[1]))
 from conftest import find_wanda_bin

--- a/tests/integration_test/test_disuse.py
+++ b/tests/integration_test/test_disuse.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 import pytest
 
-from pywandahydra.config.models import ModelSpecification, RunContext
 from pywandahydra.execution import runner
+from pywandahydra.execution.legacy import ModelSpecification, RunContext
 from pywandahydra.scenarios import ModelParameterChange, ScenarioSpecification
 from pywandahydra.wanda.api import find_items_with_keyword, get_item
 from pywandahydra.wanda.session import wanda_session

--- a/tests/integration_test/test_failed_route.py
+++ b/tests/integration_test/test_failed_route.py
@@ -13,8 +13,8 @@ from unittest.mock import patch
 
 import pytest
 
-from pywandahydra.config.models import ModelSpecification, RunContext
 from pywandahydra.execution import runner
+from pywandahydra.execution.legacy import ModelSpecification, RunContext
 from pywandahydra.postprocessing.io.cache import ParquetCache
 from pywandahydra.scenarios import (
     FigurePostProcessingConfiguration,

--- a/tests/unit_test/execution/test_artifacts.py
+++ b/tests/unit_test/execution/test_artifacts.py
@@ -5,8 +5,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from pywandahydra.config.models import ModelSpecification, RunContext
 from pywandahydra.execution.artifacts import create_run_directories, write_run_log
+from pywandahydra.execution.legacy import ModelSpecification, RunContext
 from pywandahydra.scenarios import ScenarioSpecification
 
 

--- a/tests/unit_test/execution/test_resume_policy.py
+++ b/tests/unit_test/execution/test_resume_policy.py
@@ -5,9 +5,9 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from pywandahydra.config.models import ModelSpecification
 from pywandahydra.execution.case_plan import CasePlan
 from pywandahydra.execution.journal import CaseJournal, resume_decision
+from pywandahydra.execution.legacy import ModelSpecification
 from pywandahydra.execution.worker import run_one_case
 from pywandahydra.scenarios import ScenarioSpecification
 

--- a/tests/unit_test/execution/test_runner.py
+++ b/tests/unit_test/execution/test_runner.py
@@ -5,9 +5,9 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from pywandahydra.config.models import ModelSpecification, RunContext
 from pywandahydra.execution import runner
 from pywandahydra.execution.journal import CaseJournal
+from pywandahydra.execution.legacy import ModelSpecification, RunContext
 from pywandahydra.scenarios import ScenarioSpecification
 from unit_test.wanda.fakes import FakeWandaModelAccess
 
@@ -164,4 +164,3 @@ class TestRunner(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/unit_test/execution/test_worker_failure.py
+++ b/tests/unit_test/execution/test_worker_failure.py
@@ -7,9 +7,9 @@ from unittest.mock import patch
 
 from filelock import FileLock
 
-from pywandahydra.config.models import ModelSpecification
 from pywandahydra.execution.case_plan import CasePlan
 from pywandahydra.execution.journal import CaseJournal
+from pywandahydra.execution.legacy import ModelSpecification
 from pywandahydra.execution.worker import run_one_case
 from pywandahydra.scenarios import ScenarioSpecification
 from unit_test.wanda.fakes import FailingWandaModelAccess, FakeWandaModelAccess

--- a/tests/unit_test/execution/test_worker_with_fake_adapter.py
+++ b/tests/unit_test/execution/test_worker_with_fake_adapter.py
@@ -5,8 +5,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from pywandahydra.config.models import ModelSpecification
 from pywandahydra.execution.case_plan import CasePlan
+from pywandahydra.execution.legacy import ModelSpecification
 from pywandahydra.execution.worker import run_one_case
 from pywandahydra.scenarios import ScenarioSpecification
 from unit_test.wanda.fakes import FakeWandaModelAccess

--- a/tests/unit_test/postprocessing/test_methodology_config.py
+++ b/tests/unit_test/postprocessing/test_methodology_config.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
-from pywandahydra.config.loader import ExecutionConfig
 from pywandahydra.postprocessing.core.context import CaseContext, PostProcessingRunContext
 from pywandahydra.postprocessing.io.cache import ParquetCache
 from pywandahydra.postprocessing.workflows import bootstrap
@@ -15,11 +14,6 @@ from pywandahydra.scenarios import ScenarioSpecification
 
 
 class TestWorkflowConfig(unittest.TestCase):
-    def test_execution_config_accepts_bare_workflow_string(self) -> None:
-        cfg = ExecutionConfig.model_validate({"workflow": "default"})
-        self.assertEqual(cfg.workflow.name, "default")
-        self.assertEqual(cfg.workflow.params, {})
-
     def test_resolve_workflow_rejects_unknown(self) -> None:
         bootstrap()
         with self.assertRaises(KeyError):

--- a/tests/unit_test/scenarios/test_scenario.py
+++ b/tests/unit_test/scenarios/test_scenario.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 import pandas as pd
 
-from pywandahydra.config.models import ModelSpecification
 from pywandahydra.execution.case_plan import build_case_plans
+from pywandahydra.execution.legacy import ModelSpecification
 from pywandahydra.scenarios import ScenarioLoadOptions, ScenarioSpecification, load_scenarios
 from pywandahydra.scenarios.excel.post_processing import _read_rplots_sheet, _read_tplots_sheet
 from pywandahydra.scenarios.loader import load_scenario_document

--- a/tests/unit_test/test_cli_commands.py
+++ b/tests/unit_test/test_cli_commands.py
@@ -1,304 +1,49 @@
-﻿"""Smoke tests for the pywandahydra CLI commands.
-
-These exercise the typer app via CliRunner without requiring WANDA â€”
-covering argument parsing, error handling, and output formatting for
-the `run`, `status`, `validate`, and `plot` subcommands.
-"""
+"""Focused tests for the S07 CLI wrappers."""
 
 from __future__ import annotations
 
-import tempfile
-import unittest
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-import yaml
 from typer.testing import CliRunner
 
 from pywandahydra.cli.commands import app
-from pywandahydra.execution.journal import CaseJournal
 from pywandahydra.execution.runner import RunResult
-from pywandahydra.scenarios import AnalysisMeta
 
 runner = CliRunner()
 
 
-def _write_run_config(tmp_dir: str) -> Path:
-    """Write a minimal but path-valid run config and return its path."""
-    tmp_path = Path(tmp_dir)
-    (tmp_path / "bin").mkdir()
-    (tmp_path / "model.wdi").write_bytes(b"model")
-    (tmp_path / "scenarios.xls").write_bytes(b"scenarios")
+def test_run_delegates_to_root_api(tmp_path: Path) -> None:
+    config_path = tmp_path / "run.yaml"
+    config_path.write_text("run_id: run\n", encoding="utf-8")
+    plan = SimpleNamespace(cases=(object(), object()))
+    result = RunResult("run", 2, 2, 2, 0)
 
-    config_path = tmp_path / "config.yaml"
-    config_path.write_text(
-        yaml.safe_dump(
-            {
-                "model": {
-                    "model_path": "model.wdi",
-                    "wanda_bin": "bin",
-                    "base_model_name": "base_model",
-                },
-                "scenario_file": "scenarios.xls",
-            }
-        ),
-        encoding="utf-8",
+    with (
+        patch("pywandahydra.run.prepare_run", return_value=plan) as prepare,
+        patch("pywandahydra.run.execute_run", return_value=result),
+        patch("pywandahydra.cli.commands.faulthandler.enable"),
+    ):
+        invocation = runner.invoke(app, ["run", str(config_path), "--workers", "2", "--resume"])
+
+    assert invocation.exit_code == 0
+    prepare.assert_called_once_with(config_path, workers=2, resume=True, preflight=True)
+    assert "Run complete: 2 succeeded" in invocation.output
+
+
+def test_validate_delegates_to_root_api(tmp_path: Path) -> None:
+    config_path = tmp_path / "run.yaml"
+    config_path.write_text("run_id: run\n", encoding="utf-8")
+    plan = SimpleNamespace(
+        configuration=SimpleNamespace(run_id="run", execution=SimpleNamespace(workers=1)),
+        scenario_document=SimpleNamespace(scenarios=(object(),)),
+        cases=(object(),),
     )
-    return config_path
 
+    with patch("pywandahydra.run.validate_run", return_value=plan) as validate:
+        invocation = runner.invoke(app, ["validate", str(config_path)])
 
-class TestStatusCommand(unittest.TestCase):
-    def test_status_errors_when_no_scenarios_dir(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            result = runner.invoke(app, ["status", tmp_dir])
-
-            self.assertEqual(result.exit_code, 1)
-            self.assertIn("No scenarios directory found", result.output)
-
-    def test_status_reports_no_cases(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            (Path(tmp_dir) / "scenarios").mkdir()
-
-            result = runner.invoke(app, ["status", tmp_dir])
-
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("No cases found", result.output)
-
-    def test_status_reports_case_state(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            case_dir = Path(tmp_dir) / "scenarios" / "case_001"
-            journal = CaseJournal(case_dir)
-            with journal:
-                journal.transition(
-                    "SUCCEEDED",
-                    duration_s=1.23,
-                    postprocess_status="DONE",
-                    config_hash="sha256:abc",
-                )
-
-            result = runner.invoke(app, ["status", tmp_dir])
-
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("case_001", result.output)
-            self.assertIn("SUCCEEDED", result.output)
-            self.assertIn("DONE", result.output)
-            self.assertIn("1.2s", result.output)
-
-    def test_status_reports_unknown_for_missing_state(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            case_dir = Path(tmp_dir) / "scenarios" / "case_002"
-            case_dir.mkdir(parents=True)
-
-            result = runner.invoke(app, ["status", tmp_dir])
-
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("case_002", result.output)
-            self.assertIn("UNKNOWN", result.output)
-
-
-class TestRunCommand(unittest.TestCase):
-    def test_run_errors_on_invalid_config(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            config_path = Path(tmp_dir) / "config.yaml"
-            config_path.write_text("not_a_known_field: 1\n", encoding="utf-8")
-
-            with patch("pywandahydra.cli.commands.faulthandler.enable"):
-                result = runner.invoke(app, ["run", str(config_path)])
-
-            self.assertEqual(result.exit_code, 1)
-            self.assertIn("Error loading config", result.output)
-
-    def test_run_errors_on_invalid_workers_option(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            config_path = _write_run_config(tmp_dir)
-
-            with patch("pywandahydra.cli.commands.faulthandler.enable"):
-                result = runner.invoke(app, ["run", str(config_path), "--workers", "0"])
-
-            self.assertEqual(result.exit_code, 1)
-            self.assertIn("--workers must be >= 1", result.output)
-
-    def test_run_errors_on_invalid_runtime_paths(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            (tmp_path / "bin").mkdir()
-            # scenario file deliberately missing
-
-            config_path = tmp_path / "config.yaml"
-            config_path.write_text(
-                yaml.safe_dump(
-                    {
-                        "model": {
-                            "model_path": "missing_model.wdi",
-                            "wanda_bin": "bin",
-                            "base_model_name": "base_model",
-                        },
-                        "scenario_file": "scenarios.xls",
-                    }
-                ),
-                encoding="utf-8",
-            )
-
-            with patch("pywandahydra.cli.commands.faulthandler.enable"):
-                result = runner.invoke(app, ["run", str(config_path)])
-
-            self.assertEqual(result.exit_code, 1)
-            self.assertIn("Invalid runtime configuration", result.output)
-
-    def test_run_errors_when_scenario_loading_fails(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            config_path = _write_run_config(tmp_dir)
-
-            with (
-                patch("pywandahydra.cli.commands.faulthandler.enable"),
-                patch(
-                    "pywandahydra.scenarios.loader.load_scenario_document",
-                    side_effect=ValueError("bad scenarios"),
-                ),
-            ):
-                result = runner.invoke(app, ["run", str(config_path)])
-
-            self.assertEqual(result.exit_code, 1)
-            self.assertIn("Error loading scenarios", result.output)
-
-    def test_run_errors_when_preflight_validation_fails(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            config_path = _write_run_config(tmp_dir)
-
-            with (
-                patch("pywandahydra.cli.commands.faulthandler.enable"),
-                patch(
-                    "pywandahydra.scenarios.loader.load_scenario_document",
-                    return_value=SimpleNamespace(scenarios=[], analysis_metadata=AnalysisMeta()),
-                ),
-                patch(
-                    "pywandahydra.wanda.validation.assert_preflight_valid",
-                    side_effect=ValueError("preflight failed"),
-                ),
-            ):
-                result = runner.invoke(app, ["run", str(config_path)])
-
-            self.assertEqual(result.exit_code, 1)
-            self.assertIn("preflight failed", result.output)
-
-    def test_run_errors_when_post_processing_overrides_invalid(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            config_path = _write_run_config(tmp_dir)
-
-            with (
-                patch("pywandahydra.cli.commands.faulthandler.enable"),
-                patch(
-                    "pywandahydra.scenarios.loader.load_scenario_document",
-                    return_value=SimpleNamespace(scenarios=[], analysis_metadata=AnalysisMeta()),
-                ),
-                patch("pywandahydra.wanda.validation.assert_preflight_valid"),
-                patch(
-                    "pywandahydra.config.loader.apply_post_processing_overrides",
-                    side_effect=ValueError("bad post_processing"),
-                ),
-            ):
-                result = runner.invoke(app, ["run", str(config_path)])
-
-            self.assertEqual(result.exit_code, 1)
-            self.assertIn("Invalid post_processing config", result.output)
-
-    def test_run_completes_successfully(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            config_path = _write_run_config(tmp_dir)
-
-            success_result = RunResult(
-                run_id="run-1",
-                n_total=1,
-                n_selected=1,
-                n_success=1,
-                n_failed=0,
-                n_skipped=0,
-                results=[],
-            )
-
-            with (
-                patch("pywandahydra.cli.commands.faulthandler.enable"),
-                patch(
-                    "pywandahydra.scenarios.loader.load_scenario_document",
-                    return_value=SimpleNamespace(scenarios=[], analysis_metadata=AnalysisMeta()),
-                ),
-                patch("pywandahydra.wanda.validation.assert_preflight_valid"),
-                patch("pywandahydra.execution.runner.run", return_value=success_result),
-            ):
-                result = runner.invoke(app, ["run", str(config_path), "--resume"])
-
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("Run complete: 1 succeeded", result.output)
-
-    def test_run_exits_nonzero_when_cases_fail(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            config_path = _write_run_config(tmp_dir)
-
-            failed_result = RunResult(
-                run_id="run-1",
-                n_total=1,
-                n_selected=1,
-                n_success=0,
-                n_failed=1,
-                n_skipped=0,
-                results=[],
-            )
-
-            with (
-                patch("pywandahydra.cli.commands.faulthandler.enable"),
-                patch(
-                    "pywandahydra.scenarios.loader.load_scenario_document",
-                    return_value=SimpleNamespace(scenarios=[], analysis_metadata=AnalysisMeta()),
-                ),
-                patch("pywandahydra.wanda.validation.assert_preflight_valid"),
-                patch("pywandahydra.execution.runner.run", return_value=failed_result),
-            ):
-                result = runner.invoke(app, ["run", str(config_path)])
-
-            self.assertEqual(result.exit_code, 1)
-            self.assertIn("1 failed", result.output)
-
-
-class TestValidateCommand(unittest.TestCase):
-    def test_validate_reports_invalid_config(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            config_path = Path(tmp_dir) / "config.yaml"
-            config_path.write_text("not_a_known_field: 1\n", encoding="utf-8")
-
-            result = runner.invoke(app, ["validate", str(config_path)])
-
-            self.assertEqual(result.exit_code, 1)
-            self.assertIn("Config INVALID", result.output)
-
-    def test_validate_reports_invalid_runtime_paths(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            (tmp_path / "bin").mkdir()
-            (tmp_path / "scenarios.xls").write_bytes(b"scenarios")
-
-            config_path = tmp_path / "config.yaml"
-            config_path.write_text(
-                yaml.safe_dump(
-                    {
-                        "model": {
-                            "model_path": "missing_model.wdi",
-                            "wanda_bin": "bin",
-                            "base_model_name": "base_model",
-                        },
-                        "scenario_file": "scenarios.xls",
-                    }
-                ),
-                encoding="utf-8",
-            )
-
-            result = runner.invoke(app, ["validate", str(config_path)])
-
-            self.assertEqual(result.exit_code, 1)
-            self.assertIn("Config OK", result.output)
-            self.assertIn("Runtime paths INVALID", result.output)
-
-
-if __name__ == "__main__":
-    unittest.main()
-
+    assert invocation.exit_code == 0
+    validate.assert_called_once_with(config_path)
+    assert "Validation passed." in invocation.output

--- a/tests/unit_test/test_config_loader.py
+++ b/tests/unit_test/test_config_loader.py
@@ -1,324 +1,57 @@
-﻿"""Unit tests for run configuration loading and validation."""
+"""Tests for authored run configuration parsing."""
 
 from __future__ import annotations
 
 import json
-import tempfile
-import unittest
 from pathlib import Path
 
+import pytest
 import yaml
 
-from pywandahydra.config.loader import (
-    RunConfig,
-    apply_post_processing_overrides,
-    build_run_context,
-    config_hash,
-    load_run_config,
-    validate_run_paths,
-)
-from pywandahydra.scenarios import ScenarioSpecification
+from pywandahydra.config import RunConfiguration, load_run_config
 
 
-def _minimal_config_dict(*, model_path: str, wanda_bin: str, scenario_file: str) -> dict:
+def _configuration() -> dict[str, object]:
     return {
-        "model": {
-            "model_path": model_path,
-            "wanda_bin": wanda_bin,
-            "base_model_name": "base_model",
-        },
-        "scenario_file": scenario_file,
+        "run_id": "run_001",
+        "output_root": "runs",
+        "scenario_file": "scenarios.xlsx",
+        "model": {"path": "model.wdi", "wanda_bin": "bin"},
+        "simulation": {"steady": True, "unsteady": False},
+        "execution": {"workers": 2, "resume": True},
+        "outputs": {"figure_formats": ["pdf"], "table_formats": ["csv"]},
     }
 
 
-class TestLoadRunConfig(unittest.TestCase):
-    def test_load_yaml_config(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            config_path = tmp_path / "config.yaml"
-            config_path.write_text(
-                yaml.safe_dump(
-                    _minimal_config_dict(
-                        model_path="model.wdi",
-                        wanda_bin="bin",
-                        scenario_file="scenarios.xls",
-                    )
-                ),
-                encoding="utf-8",
-            )
+def test_load_yaml_configuration(tmp_path: Path) -> None:
+    path = tmp_path / "run.yaml"
+    path.write_text(yaml.safe_dump(_configuration()), encoding="utf-8")
 
-            cfg = load_run_config(config_path)
+    configuration = load_run_config(path)
 
-            self.assertEqual(cfg.model.base_model_name, "base_model")
-            self.assertEqual(cfg.execution.n_workers, 1)
+    assert configuration.execution.workers == 2
+    assert configuration.model.path == Path("model.wdi")
+    assert configuration.outputs.figure_formats == ("pdf",)
 
-    def test_load_json_config(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            config_path = tmp_path / "config.json"
-            config_path.write_text(
-                json.dumps(
-                    _minimal_config_dict(
-                        model_path="model.wdi",
-                        wanda_bin="bin",
-                        scenario_file="scenarios.xls",
-                    )
-                ),
-                encoding="utf-8",
-            )
 
-            cfg = load_run_config(config_path)
+def test_load_json_configuration(tmp_path: Path) -> None:
+    path = tmp_path / "run.json"
+    path.write_text(json.dumps(_configuration()), encoding="utf-8")
 
-            self.assertEqual(cfg.scenario_file, Path("scenarios.xls"))
+    assert load_run_config(path).run_id == "run_001"
 
-    def test_missing_file_raises_file_not_found(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            missing = Path(tmp_dir) / "does_not_exist.yaml"
 
-            with self.assertRaises(FileNotFoundError):
-                load_run_config(missing)
+def test_rejects_removed_authored_keys() -> None:
+    data = _configuration()
+    data["model"] = {"path": "model.wdi", "wanda_bin": "bin", "base_model_name": "model"}
 
-    def test_unsupported_extension_raises_value_error(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            config_path = Path(tmp_dir) / "config.txt"
-            config_path.write_text("model: {}", encoding="utf-8")
+    with pytest.raises(ValueError, match="base_model_name"):
+        RunConfiguration.model_validate(data)
 
-            with self.assertRaises(ValueError) as ctx:
-                load_run_config(config_path)
 
-            self.assertIn("Unsupported config format", str(ctx.exception))
+def test_rejects_non_mapping_configuration(tmp_path: Path) -> None:
+    path = tmp_path / "run.yaml"
+    path.write_text("- one\n- two\n", encoding="utf-8")
 
-    def test_non_mapping_content_raises_value_error(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            config_path = Path(tmp_dir) / "config.yaml"
-            config_path.write_text("- a\n- b\n", encoding="utf-8")
-
-            with self.assertRaises(ValueError) as ctx:
-                load_run_config(config_path)
-
-            self.assertIn("must contain a mapping", str(ctx.exception))
-
-    def test_bare_workflow_string_is_coerced(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            config_path = Path(tmp_dir) / "config.yaml"
-            data = _minimal_config_dict(
-                model_path="model.wdi", wanda_bin="bin", scenario_file="scenarios.xls"
-            )
-            data["execution"] = {"workflow": "default"}
-            config_path.write_text(yaml.safe_dump(data), encoding="utf-8")
-
-            cfg = load_run_config(config_path)
-
-            self.assertEqual(cfg.execution.workflow.name, "default")
-
-    def test_custom_extractors_are_rejected(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            config_path = Path(tmp_dir) / "config.yaml"
-            data = _minimal_config_dict(
-                model_path="model.wdi", wanda_bin="bin", scenario_file="scenarios.xls"
-            )
-            data["execution"] = {"extractors": [{"name": "external"}]}
-            config_path.write_text(yaml.safe_dump(data), encoding="utf-8")
-
-            with self.assertRaises(ValueError) as ctx:
-                load_run_config(config_path)
-
-            self.assertIn("extractors", str(ctx.exception))
-
-
-class TestValidateRunPaths(unittest.TestCase):
-    def _write_config(self, tmp_path: Path) -> tuple[RunConfig, Path]:
-        model_dir = tmp_path
-        model_path = model_dir / "model.wdi"
-        model_path.write_bytes(b"model")
-        wanda_bin = model_dir / "bin"
-        wanda_bin.mkdir()
-        scenario_file = model_dir / "scenarios.xls"
-        scenario_file.write_bytes(b"scenarios")
-
-        cfg = RunConfig.model_validate(
-            _minimal_config_dict(
-                model_path="model.wdi", wanda_bin="bin", scenario_file="scenarios.xls"
-            )
-            | {"output_root": "runs"}
-        )
-        return cfg, tmp_path
-
-    def test_validate_resolves_relative_paths(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            cfg, tmp_path = self._write_config(Path(tmp_dir))
-
-            validate_run_paths(cfg, config_dir=tmp_path)
-
-            self.assertTrue(cfg.model.model_path.is_absolute())
-            self.assertEqual(cfg.model.model_path, tmp_path / "model.wdi")
-            self.assertTrue(cfg.output_root.exists())
-
-    def test_validate_rejects_non_wdi_model_path(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            (tmp_path / "model.txt").write_bytes(b"model")
-            (tmp_path / "bin").mkdir()
-            (tmp_path / "scenarios.xls").write_bytes(b"scenarios")
-
-            cfg = RunConfig.model_validate(
-                _minimal_config_dict(
-                    model_path="model.txt",
-                    wanda_bin="bin",
-                    scenario_file="scenarios.xls",
-                )
-            )
-
-            with self.assertRaises(ValueError) as ctx:
-                validate_run_paths(cfg, config_dir=tmp_path)
-
-            self.assertIn(".wdi", str(ctx.exception))
-
-    def test_validate_rejects_missing_model_file(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            (tmp_path / "bin").mkdir()
-            (tmp_path / "scenarios.xls").write_bytes(b"scenarios")
-
-            cfg = RunConfig.model_validate(
-                _minimal_config_dict(
-                    model_path="missing.wdi",
-                    wanda_bin="bin",
-                    scenario_file="scenarios.xls",
-                )
-            )
-
-            with self.assertRaises(ValueError) as ctx:
-                validate_run_paths(cfg, config_dir=tmp_path)
-
-            self.assertIn("does not exist", str(ctx.exception))
-
-    def test_validate_rejects_missing_wanda_bin_dir(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            (tmp_path / "model.wdi").write_bytes(b"model")
-            (tmp_path / "scenarios.xls").write_bytes(b"scenarios")
-
-            cfg = RunConfig.model_validate(
-                _minimal_config_dict(
-                    model_path="model.wdi",
-                    wanda_bin="missing_bin",
-                    scenario_file="scenarios.xls",
-                )
-            )
-
-            with self.assertRaises(ValueError) as ctx:
-                validate_run_paths(cfg, config_dir=tmp_path)
-
-            self.assertIn("wanda_bin", str(ctx.exception))
-
-    def test_validate_rejects_missing_scenario_file(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            (tmp_path / "model.wdi").write_bytes(b"model")
-            (tmp_path / "bin").mkdir()
-
-            cfg = RunConfig.model_validate(
-                _minimal_config_dict(
-                    model_path="model.wdi",
-                    wanda_bin="bin",
-                    scenario_file="missing.xls",
-                )
-            )
-
-            with self.assertRaises(ValueError) as ctx:
-                validate_run_paths(cfg, config_dir=tmp_path)
-
-            self.assertIn("scenario_file", str(ctx.exception))
-
-
-class TestApplyPostProcessingOverrides(unittest.TestCase):
-    def _scenario(self) -> ScenarioSpecification:
-        return ScenarioSpecification(number=1, include=True, name="case_001")
-
-    def test_no_theme_configured_is_noop(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            (tmp_path / "model.wdi").write_bytes(b"model")
-            (tmp_path / "bin").mkdir()
-            (tmp_path / "scenarios.xls").write_bytes(b"scenarios")
-
-            cfg = RunConfig.model_validate(
-                _minimal_config_dict(
-                    model_path="model.wdi", wanda_bin="bin", scenario_file="scenarios.xls"
-                )
-            )
-            scenario = self._scenario()
-
-            # No theme configured: validation is a no-op and must not raise.
-            apply_post_processing_overrides(cfg, [scenario])
-
-    def test_known_theme_validates_without_error(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            (tmp_path / "model.wdi").write_bytes(b"model")
-            (tmp_path / "bin").mkdir()
-            (tmp_path / "scenarios.xls").write_bytes(b"scenarios")
-
-            data = _minimal_config_dict(
-                model_path="model.wdi", wanda_bin="bin", scenario_file="scenarios.xls"
-            )
-            data["post_processing"] = {"theme": "deltares_light"}
-            cfg = RunConfig.model_validate(data)
-            scenario = self._scenario()
-
-            # A registered theme validates cleanly.
-            apply_post_processing_overrides(cfg, [scenario])
-
-    def test_unknown_theme_raises_value_error(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            (tmp_path / "model.wdi").write_bytes(b"model")
-            (tmp_path / "bin").mkdir()
-            (tmp_path / "scenarios.xls").write_bytes(b"scenarios")
-
-            data = _minimal_config_dict(
-                model_path="model.wdi", wanda_bin="bin", scenario_file="scenarios.xls"
-            )
-            data["post_processing"] = {"theme": "does_not_exist"}
-            cfg = RunConfig.model_validate(data)
-
-            with self.assertRaises(ValueError) as ctx:
-                apply_post_processing_overrides(cfg, [self._scenario()])
-
-            self.assertIn("not registered", str(ctx.exception))
-
-
-class TestConfigHashAndRunContext(unittest.TestCase):
-    def _cfg(self, run_id: str = "run_001") -> RunConfig:
-        data = _minimal_config_dict(
-            model_path="model.wdi", wanda_bin="bin", scenario_file="scenarios.xls"
-        )
-        data["run_id"] = run_id
-        return RunConfig.model_validate(data)
-
-    def test_config_hash_is_deterministic(self) -> None:
-        cfg_a = self._cfg()
-        cfg_b = self._cfg()
-
-        self.assertEqual(config_hash(cfg_a), config_hash(cfg_b))
-        self.assertTrue(config_hash(cfg_a).startswith("sha256:"))
-
-    def test_config_hash_differs_for_different_run_id(self) -> None:
-        cfg_a = self._cfg(run_id="run_001")
-        cfg_b = self._cfg(run_id="run_002")
-
-        self.assertNotEqual(config_hash(cfg_a), config_hash(cfg_b))
-
-    def test_build_run_context_uses_output_root_and_run_id(self) -> None:
-        cfg = self._cfg(run_id="run_001")
-
-        ctx = build_run_context(cfg)
-
-        self.assertEqual(ctx.run_id, "run_001")
-        self.assertEqual(ctx.root_dir, cfg.output_root / "run_001")
-
-
-if __name__ == "__main__":
-    unittest.main()
-
+    with pytest.raises(ValueError, match="must contain a mapping"):
+        load_run_config(path)

--- a/tests/unit_test/test_run_api.py
+++ b/tests/unit_test/test_run_api.py
@@ -1,0 +1,92 @@
+"""Tests for S07 root run preparation and execution bridge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from pywandahydra.run import execute_run, prepare_run, validate_run
+from pywandahydra.scenarios import AnalysisMeta, ScenarioSpecification
+
+
+def _write_configuration(tmp_path: Path) -> Path:
+    (tmp_path / "bin").mkdir()
+    (tmp_path / "model.wdi").write_bytes(b"model")
+    (tmp_path / "scenarios.xlsx").write_bytes(b"scenarios")
+    path = tmp_path / "run.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "run_id": "run_001",
+                "output_root": "runs",
+                "scenario_file": "scenarios.xlsx",
+                "model": {"path": "model.wdi", "wanda_bin": "bin"},
+                "simulation": {"steady": False, "unsteady": False},
+                "execution": {"workers": 1, "resume": False},
+                "outputs": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _document(path: Path, *names: str) -> SimpleNamespace:
+    scenarios = tuple(
+        ScenarioSpecification(number=index, include=True, name=name)
+        for index, name in enumerate(names, 1)
+    )
+    return SimpleNamespace(scenarios=scenarios, analysis_metadata=AnalysisMeta(), source_path=path)
+
+
+def test_prepare_run_resolves_paths_without_writing(tmp_path: Path) -> None:
+    path = _write_configuration(tmp_path)
+    document = _document(tmp_path / "scenarios.xlsx", "case_one")
+
+    with patch("pywandahydra.run.load_scenario_document", return_value=document):
+        plan = prepare_run(path)
+
+    assert plan.configuration.model.path == Path("model.wdi")
+    assert plan.model_path == tmp_path / "model.wdi"
+    assert plan.run_dir == tmp_path / "runs" / "run_001"
+    assert len(plan.cases) == 1
+    assert not plan.run_dir.exists()
+
+
+def test_prepare_run_validates_case_names(tmp_path: Path) -> None:
+    path = _write_configuration(tmp_path)
+    document = _document(tmp_path / "scenarios.xlsx", "../unsafe")
+
+    with patch("pywandahydra.run.load_scenario_document", return_value=document):
+        with pytest.raises(ValueError, match="safe path names"):
+            prepare_run(path, workers=2, resume=True)
+
+
+def test_validate_run_is_wanda_free_by_default(tmp_path: Path) -> None:
+    path = _write_configuration(tmp_path)
+    document = _document(tmp_path / "scenarios.xlsx", "case_one")
+
+    with (
+        patch("pywandahydra.run.load_scenario_document", return_value=document),
+        patch("pywandahydra.wanda.validation.assert_preflight_valid") as preflight,
+    ):
+        validate_run(path)
+
+    preflight.assert_not_called()
+
+
+def test_execute_run_delegates_to_current_runner(tmp_path: Path) -> None:
+    path = _write_configuration(tmp_path)
+    document = _document(tmp_path / "scenarios.xlsx", "case_one")
+    expected = object()
+
+    with patch("pywandahydra.run.load_scenario_document", return_value=document):
+        plan = prepare_run(path)
+    with patch("pywandahydra.execution.runner.run", return_value=expected) as runner:
+        assert execute_run(plan) is expected
+
+    assert runner.call_args.kwargs["model"].model_path == tmp_path / "model.wdi"

--- a/tests/unit_test/wanda/conftest.py
+++ b/tests/unit_test/wanda/conftest.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from pywandahydra.config.models import ModelSpecification
+from pywandahydra.execution.legacy import ModelSpecification
 
 sys.path.insert(0, str(Path(__file__).parents[2]))
 from conftest import find_wanda_bin

--- a/tests/unit_test/wanda/fakes.py
+++ b/tests/unit_test/wanda/fakes.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import numpy as np
 
-from pywandahydra.config.models import ModelSpecification
+from pywandahydra.execution.legacy import ModelSpecification
 from pywandahydra.scenarios import ModelParameterChange
 
 ModelHandle = Any
@@ -122,4 +122,3 @@ class FailingWandaModelAccess(FakeWandaModelAccess):
 # Backward-compatible aliases for older test names.
 FakeWandaAdapter = FakeWandaModelAccess
 FailingWandaAdapter = FailingWandaModelAccess
-

--- a/tests/unit_test/wanda/test_api.py
+++ b/tests/unit_test/wanda/test_api.py
@@ -5,7 +5,7 @@ import sys
 import unittest
 from pathlib import Path
 
-from pywandahydra.config.models import ModelSpecification
+from pywandahydra.execution.legacy import ModelSpecification
 from pywandahydra.scenarios import ModelParameterChange
 from pywandahydra.wanda.api import (
     WandaItemRef,

--- a/tests/unit_test/wanda/test_pywanda_adapter.py
+++ b/tests/unit_test/wanda/test_pywanda_adapter.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import numpy as np
 
-from pywandahydra.config.models import ModelSpecification
+from pywandahydra.execution.legacy import ModelSpecification
 from pywandahydra.scenarios import ModelParameterChange
 from pywandahydra.wanda.pywanda_model_access import PywandaModelAccess
 

--- a/tests/unit_test/wanda/test_validation.py
+++ b/tests/unit_test/wanda/test_validation.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
-from pywandahydra.config.models import ModelSpecification
+from pywandahydra.execution.legacy import ModelSpecification
 from pywandahydra.scenarios import (
     FigurePostProcessingConfiguration,
     MinMaxTableSpecification,

--- a/tests/unit_test/wanda/test_wanda_session.py
+++ b/tests/unit_test/wanda/test_wanda_session.py
@@ -6,7 +6,7 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from pywandahydra.config.models import ModelSpecification
+from pywandahydra.execution.legacy import ModelSpecification
 from pywandahydra.wanda.session import wanda_session
 
 # Import shared helper from root conftest


### PR DESCRIPTION
Implements Slice 07 against the `refactor` integration branch and updates the refactor tracker: Slices 01-06 are merged; Slice 07 is under review.

Summary:
- add immutable authored run configuration models and loader
- add root `prepare_run`, `validate_run`, and temporary `execute_run` APIs
- introduce `RunPlan` and isolate compatibility-only legacy engine contracts
- migrate CLI and config-driven example setup to the root API

Validation:
- `uv run pytest -o addopts='' tests/unit_test/test_config_loader.py tests/unit_test/test_cli_commands.py tests/unit_test/test_run_api.py tests/unit_test/execution/test_runner.py -q` (13 passed)
- focused Ruff and mypy checks passed
- `git diff --check` passed

Supersedes #36, which was opened against the wrong base branch.