### PR TITLE
Refactor slice 08 results foundation

### DIFF
--- a/.github/plans/refactor/00-tracker.md
+++ b/.github/plans/refactor/00-tracker.md
@@ -14,7 +14,8 @@ Older A-J plans are superseded. Do not implement workflow discriminated unions,
 
 - Repository default branch: `master` at `8b34cf7` when the v2 work began.
 - Integration branch: `refactor`, containing merged Slices 01 through 06.
-- Slice 07 is implemented locally and under review.
+- Slice 07 is under review on `refactor-v2/07-config-run-api`.
+- Slice 08 is active on `refactor-v2/08-results`.
 
 ## Status
 
@@ -26,8 +27,8 @@ Older A-J plans are superseded. Do not implement workflow discriminated unions,
 | 04 | [`04-scenario-document.md`](04-scenario-document.md) | `refactor-v2/04-scenario-document` | 02 | medium | merged into `refactor` |
 | 05 | [`05-scenario-models.md`](05-scenario-models.md) | `refactor-v2/05-scenario-models` | 03, 04 | high | merged into `refactor` |
 | 06 | [`06-excel-loader.md`](06-excel-loader.md) | `refactor-v2/06-excel-loader` | 05 | medium | merged into `refactor` |
-| 07 | [`07-config-run-api.md`](07-config-run-api.md) | `refactor` | 03, 04, 05, 06 | high | in review; focused checks passed |
-| 08 | [`08-results-foundation.md`](08-results-foundation.md) | `refactor-v2/08-results` | 07 | high | pending |
+| 07 | [`07-config-run-api.md`](07-config-run-api.md) | `refactor-v2/07-config-run-api` | 03, 04, 05, 06 | high | in review; focused checks passed |
+| 08 | [`08-results-foundation.md`](08-results-foundation.md) | `refactor-v2/08-results` | 07 | high | active; focused checks passed |
 | 09A | [`09a-result-extraction.md`](09a-result-extraction.md) | `refactor-v2/09a-extraction` | 03, 05, 08 | high | pending |
 | 09B | [`09b-tables.md`](09b-tables.md) | `refactor-v2/09b-tables` | 09A | medium | pending; parallel window with 09C |
 | 09C | [`09c-figures.md`](09c-figures.md) | `refactor-v2/09c-figures` | 09A | high | pending; parallel window with 09B |

--- a/src/pywandahydra/results/__init__.py
+++ b/src/pywandahydra/results/__init__.py
@@ -1,0 +1,12 @@
+"""Durable, WANDA-free simulation result contracts and storage."""
+
+from .models import (
+    ComponentIdentity,
+    ComponentTimeSeries,
+    ExtractedSimulationData,
+    RouteData,
+    RouteIdentity,
+    RouteProductIdentity,
+)
+from .requirements import DataRequirements, ResultInventory
+from .store import ParquetResultStore

--- a/src/pywandahydra/results/models.py
+++ b/src/pywandahydra/results/models.py
@@ -1,0 +1,95 @@
+"""WANDA-free scientific result contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Literal, cast
+
+import pandas as pd
+
+RouteProduct = Literal["timeseries", "envelope", "profile"]
+
+
+@dataclass(frozen=True, order=True, slots=True)
+class ComponentIdentity:
+    """Stable identity for one component output column."""
+
+    component: str
+    property: str
+    location: float | None = None
+
+
+@dataclass(frozen=True, order=True, slots=True)
+class RouteIdentity:
+    """Stable route/property identity independent of display metadata."""
+
+    route_id: str
+    property: str
+
+
+@dataclass(frozen=True, order=True, slots=True)
+class RouteProductIdentity:
+    """Stable identity for one product generated for a route property."""
+
+    route: RouteIdentity
+    product: RouteProduct
+
+
+@dataclass(frozen=True, slots=True)
+class ComponentTimeSeries:
+    """Component output time series with owned DataFrame payload."""
+
+    data: pd.DataFrame
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "data", self.data.copy(deep=True))
+
+
+@dataclass(frozen=True, slots=True)
+class RouteData:
+    """Owned route products for one stable route/property identity."""
+
+    timeseries: pd.DataFrame | None = None
+    envelope: pd.DataFrame | None = None
+    profile: pd.DataFrame | None = None
+
+    def __post_init__(self) -> None:
+        for product in ("timeseries", "envelope", "profile"):
+            value = getattr(self, product)
+            if value is not None:
+                object.__setattr__(self, product, value.copy(deep=True))
+
+    def products(self) -> tuple[RouteProduct, ...]:
+        """Return products present in this payload."""
+        return tuple(
+            cast(RouteProduct, product)
+            for product in ("timeseries", "envelope", "profile")
+            if getattr(self, product) is not None
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractedSimulationData:
+    """All WANDA-free data extracted for one simulated case."""
+
+    components: ComponentTimeSeries = field(
+        default_factory=lambda: ComponentTimeSeries(pd.DataFrame())
+    )
+    routes: Mapping[RouteIdentity, RouteData] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        copied_routes = {identity: data for identity, data in self.routes.items()}
+        object.__setattr__(self, "routes", MappingProxyType(copied_routes))
+
+
+def component_identities(data: ComponentTimeSeries) -> frozenset[ComponentIdentity]:
+    """Derive stable component identities from three-level component columns."""
+    if not isinstance(data.data.columns, pd.MultiIndex) or data.data.columns.nlevels != 3:
+        return frozenset()
+    identities: set[ComponentIdentity] = set()
+    for component, property_name, location in data.data.columns:
+        numeric_location = None if pd.isna(location) else float(location)
+        identities.add(ComponentIdentity(str(component), str(property_name), numeric_location))
+    return frozenset(identities)

--- a/src/pywandahydra/results/requirements.py
+++ b/src/pywandahydra/results/requirements.py
@@ -1,0 +1,55 @@
+"""Explicit raw-data requirements and available-result inventory."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .models import (
+    ComponentIdentity,
+    ExtractedSimulationData,
+    RouteProductIdentity,
+    component_identities,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DataRequirements:
+    """Raw result identities required by a downstream operation."""
+
+    components: frozenset[ComponentIdentity] = field(default_factory=frozenset)
+    route_products: frozenset[RouteProductIdentity] = field(default_factory=frozenset)
+
+    def missing_from(self, inventory: ResultInventory) -> DataRequirements:
+        """Return the portion of this requirement not present in ``inventory``."""
+        return DataRequirements(
+            components=self.components - inventory.components,
+            route_products=self.route_products - inventory.route_products,
+        )
+
+    def is_satisfied_by(self, inventory: ResultInventory) -> bool:
+        """Whether ``inventory`` contains all required raw data."""
+        return not self.missing_from(inventory).components and not self.missing_from(
+            inventory
+        ).route_products
+
+
+@dataclass(frozen=True, slots=True)
+class ResultInventory:
+    """Stable inventory of raw result identities present in a store."""
+
+    components: frozenset[ComponentIdentity] = field(default_factory=frozenset)
+    route_products: frozenset[RouteProductIdentity] = field(default_factory=frozenset)
+
+    @classmethod
+    def from_data(cls, data: ExtractedSimulationData) -> ResultInventory:
+        """Build an inventory from an extracted simulation payload."""
+        route_products = frozenset(
+            RouteProductIdentity(route, product)
+            for route, route_data in data.routes.items()
+            for product in route_data.products()
+        )
+        return cls(components=component_identities(data.components), route_products=route_products)
+
+    def satisfies(self, requirements: DataRequirements) -> bool:
+        """Whether this inventory satisfies ``requirements``."""
+        return requirements.is_satisfied_by(self)

--- a/src/pywandahydra/results/store.py
+++ b/src/pywandahydra/results/store.py
@@ -1,0 +1,222 @@
+"""Transactional Parquet persistence for extracted simulation results."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+import pandas as pd
+
+from .models import (
+    ComponentIdentity,
+    ComponentTimeSeries,
+    ExtractedSimulationData,
+    RouteData,
+    RouteIdentity,
+    RouteProductIdentity,
+)
+from .requirements import ResultInventory
+
+_MARKER_FILE = "complete.json"
+_METADATA_FILE = "inventory.json"
+_COMPONENTS_FILE = "components.parquet"
+_ROUTES_DIRECTORY = "routes"
+_SCHEMA_VERSION = 1
+
+
+class ParquetResultStore:
+    """Read and atomically commit one case's WANDA-free extracted data."""
+
+    def __init__(self, directory: Path) -> None:
+        self.directory = directory
+
+    def is_complete(self) -> bool:
+        """Return whether a valid completion marker and all hashed files exist."""
+        marker_path = self.directory / _MARKER_FILE
+        metadata_path = self.directory / _METADATA_FILE
+        if not marker_path.is_file() or not metadata_path.is_file():
+            return False
+        try:
+            marker = _read_json(marker_path)
+            if marker.get("metadata_sha256") != _sha256(metadata_path):
+                return False
+            metadata = _read_json(metadata_path)
+            return all(
+                (self.directory / relative_path).is_file()
+                and _sha256(self.directory / relative_path) == expected_hash
+                for relative_path, expected_hash in metadata["files"].items()
+            )
+        except (KeyError, OSError, ValueError, json.JSONDecodeError):
+            return False
+
+    def inventory(self) -> ResultInventory | None:
+        """Return the committed inventory, or ``None`` for incomplete stores."""
+        if not self.is_complete():
+            return None
+        return _inventory_from_json(_read_json(self.directory / _METADATA_FILE)["inventory"])
+
+    def read(self) -> ExtractedSimulationData | None:
+        """Read committed result data, or ``None`` for incomplete stores."""
+        if not self.is_complete():
+            return None
+        metadata = _read_json(self.directory / _METADATA_FILE)
+        files: dict[str, str] = metadata["files"]
+        components_path = self.directory / _COMPONENTS_FILE
+        components = ComponentTimeSeries(
+            _read_components(components_path)
+            if _COMPONENTS_FILE in files
+            else pd.DataFrame()
+        )
+        routes: dict[RouteIdentity, RouteData] = {}
+        for item in metadata["routes"]:
+            identity = RouteIdentity(item["route_id"], item["property"])
+            values: dict[str, pd.DataFrame] = {}
+            for product, relative_path in item["products"].items():
+                values[product] = pd.read_parquet(self.directory / relative_path, engine="pyarrow")
+            routes[identity] = RouteData(**values)
+        return ExtractedSimulationData(components=components, routes=routes)
+
+    def write(self, data: ExtractedSimulationData, *, fingerprint: str) -> ResultInventory:
+        """Atomically commit ``data`` and its inventory after all Parquet writes close."""
+        self.directory.mkdir(parents=True, exist_ok=True)
+        marker_path = self.directory / _MARKER_FILE
+        marker_path.unlink(missing_ok=True)
+
+        files: dict[str, str] = {}
+        if not data.components.data.empty:
+            files[_COMPONENTS_FILE] = self._write_dataframe(
+                _COMPONENTS_FILE, _encode_component_columns(data.components.data)
+            )
+
+        routes_json: list[dict[str, Any]] = []
+        for identity, route_data in sorted(data.routes.items()):
+            products: dict[str, str] = {}
+            route_directory = _route_directory(identity)
+            for product in route_data.products():
+                relative_path = f"{_ROUTES_DIRECTORY}/{route_directory}/{product}.parquet"
+                frame = getattr(route_data, product)
+                if frame is not None:
+                    files[relative_path] = self._write_dataframe(relative_path, frame)
+                    products[product] = relative_path
+            routes_json.append(
+                {"route_id": identity.route_id, "property": identity.property, "products": products}
+            )
+
+        inventory = ResultInventory.from_data(data)
+        metadata = {
+            "schema_version": _SCHEMA_VERSION,
+            "fingerprint": fingerprint,
+            "inventory": _inventory_to_json(inventory),
+            "files": dict(sorted(files.items())),
+            "routes": routes_json,
+        }
+        metadata_path = self.directory / _METADATA_FILE
+        _atomic_json_write(metadata_path, metadata)
+        _atomic_json_write(marker_path, {"metadata_sha256": _sha256(metadata_path)})
+        return inventory
+
+    def _write_dataframe(self, relative_path: str, data: pd.DataFrame) -> str:
+        path = self.directory / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path = path.with_suffix(path.suffix + ".tmp")
+        data.to_parquet(temporary_path, engine="pyarrow")
+        os.replace(temporary_path, path)
+        return _sha256(path)
+
+
+def _route_directory(identity: RouteIdentity) -> str:
+    encoded = json.dumps([identity.route_id, identity.property], separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:20]
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"Expected object in {path}")
+    return value
+
+
+def _atomic_json_write(path: Path, value: dict[str, Any]) -> None:
+    with NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as temporary:
+        json.dump(value, temporary, sort_keys=True, separators=(",", ":"))
+        temporary_path = Path(temporary.name)
+    os.replace(temporary_path, path)
+
+
+def _encode_component_columns(data: pd.DataFrame) -> pd.DataFrame:
+    """Encode component MultiIndex columns without relying on PyArrow metadata."""
+    if not isinstance(data.columns, pd.MultiIndex) or data.columns.nlevels != 3:
+        return data
+    encoded = data.copy(deep=True)
+    encoded.columns = pd.Index(
+        [
+            json.dumps(
+                [
+                    str(component),
+                    str(property_name),
+                    None if pd.isna(location) else float(location),
+                ],
+                separators=(",", ":"),
+            )
+            for component, property_name, location in data.columns
+        ]
+    )
+    return encoded
+
+
+def _read_components(path: Path) -> pd.DataFrame:
+    """Restore typed component MultiIndex columns from explicit JSON encodings."""
+    data = pd.read_parquet(path, engine="pyarrow")
+    if not all(isinstance(column, str) for column in data.columns):
+        return data
+    try:
+        columns = [tuple(json.loads(column)) for column in data.columns]
+    except (TypeError, json.JSONDecodeError):
+        return data
+    if not all(len(column) == 3 for column in columns):
+        return data
+    restored = data.copy(deep=True)
+    restored.columns = pd.MultiIndex.from_tuples(
+        columns, names=["component", "property", "s_location"]
+    )
+    return restored
+
+
+def _inventory_to_json(inventory: ResultInventory) -> dict[str, list[dict[str, Any]]]:
+    return {
+        "components": [
+            {"component": item.component, "property": item.property, "location": item.location}
+            for item in sorted(inventory.components)
+        ],
+        "route_products": [
+            {
+                "route_id": item.route.route_id,
+                "property": item.route.property,
+                "product": item.product,
+            }
+            for item in sorted(inventory.route_products)
+        ],
+    }
+
+
+def _inventory_from_json(value: dict[str, Any]) -> ResultInventory:
+    return ResultInventory(
+        components=frozenset(
+            ComponentIdentity(item["component"], item["property"], item["location"])
+            for item in value["components"]
+        ),
+        route_products=frozenset(
+            RouteProductIdentity(
+                RouteIdentity(item["route_id"], item["property"]), item["product"]
+            )
+            for item in value["route_products"]
+        ),
+    )

--- a/tests/unit_test/results/test_requirements.py
+++ b/tests/unit_test/results/test_requirements.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from pywandahydra.results import (
+    ComponentIdentity,
+    ComponentTimeSeries,
+    DataRequirements,
+    ExtractedSimulationData,
+    ResultInventory,
+    RouteData,
+    RouteIdentity,
+    RouteProductIdentity,
+)
+
+
+def test_inventory_reports_missing_component_and_route_products() -> None:
+    route = RouteIdentity("route-001", "Pressure")
+    data = ExtractedSimulationData(
+        components=ComponentTimeSeries(
+            pd.DataFrame(
+                [[1.0]],
+                columns=pd.MultiIndex.from_tuples(
+                    [("Pump A", "Head", float("nan"))],
+                    names=["component", "property", "s_location"],
+                ),
+            )
+        ),
+        routes={route: RouteData(envelope=pd.DataFrame({"min": [1.0]}))},
+    )
+    inventory = ResultInventory.from_data(data)
+    requirements = DataRequirements(
+        components=frozenset(
+            {
+                ComponentIdentity("Pump A", "Head"),
+                ComponentIdentity("Pipe A", "Pressure", 10.0),
+            }
+        ),
+        route_products=frozenset(
+            {
+                RouteProductIdentity(route, "envelope"),
+                RouteProductIdentity(route, "profile"),
+            }
+        ),
+    )
+
+    missing = requirements.missing_from(inventory)
+
+    assert missing.components == frozenset({ComponentIdentity("Pipe A", "Pressure", 10.0)})
+    assert missing.route_products == frozenset({RouteProductIdentity(route, "profile")})
+    assert not inventory.satisfies(requirements)
+
+
+def test_inventory_uses_route_identity_not_display_name() -> None:
+    route = RouteIdentity("route-001", "Pressure")
+    inventory = ResultInventory.from_data(
+        ExtractedSimulationData(
+            routes={route: RouteData(profile=pd.DataFrame({"elevation": [1.0]}))}
+        )
+    )
+
+    assert inventory.route_products == frozenset({RouteProductIdentity(route, "profile")})

--- a/tests/unit_test/results/test_store.py
+++ b/tests/unit_test/results/test_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -134,7 +135,13 @@ def test_metadata_is_deterministic_and_uses_stable_route_identity(tmp_path: Path
 
 
 def test_results_package_does_not_import_forbidden_runtime_dependencies() -> None:
-    import pywandahydra.results  # noqa: F401
+    code = (
+        "import pywandahydra.results; import sys; "
+        "forbidden = {'pywanda', 'matplotlib', 'pywandahydra.execution', "
+        "'pywandahydra.postprocessing'}; "
+        "assert not forbidden.intersection(sys.modules)"
+    )
 
-    forbidden = {"pywanda", "matplotlib", "pywandahydra.execution", "pywandahydra.postprocessing"}
-    assert not forbidden.intersection(sys.modules)
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stderr

--- a/tests/unit_test/results/test_store.py
+++ b/tests/unit_test/results/test_store.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+from pywandahydra.results import (
+    ComponentTimeSeries,
+    ExtractedSimulationData,
+    ParquetResultStore,
+    RouteData,
+    RouteIdentity,
+)
+
+
+def _data() -> ExtractedSimulationData:
+    columns = pd.MultiIndex.from_tuples(
+        [("Pump A", "Head", float("nan")), ("Pipe A", "Pressure", 12.5)],
+        names=["component", "property", "s_location"],
+    )
+    components = pd.DataFrame(
+        [[1.0, 2.0], [3.0, 4.0]],
+        index=pd.Index([0.0, 1.0], name="time [s]"),
+        columns=columns,
+    )
+    route = RouteIdentity("route-001", "Pressure")
+    return ExtractedSimulationData(
+        components=ComponentTimeSeries(components),
+        routes={
+            route: RouteData(
+                timeseries=pd.DataFrame(
+                    [[2.0, 3.0]],
+                    index=pd.Index([0.0], name="time [s]"),
+                    columns=pd.Index([0.0, 10.0], name="s_location [m]"),
+                ),
+                envelope=pd.DataFrame(
+                    {"min": [1.0, 2.0], "max": [3.0, 4.0]},
+                    index=pd.Index([0.0, 10.0], name="s_location [m]"),
+                ),
+                profile=pd.DataFrame(
+                    {"elevation": [0.2, 0.5]},
+                    index=pd.Index([0.0, 10.0], name="s_location [m]"),
+                ),
+            )
+        },
+    )
+
+
+def test_roundtrip_preserves_multiindex_and_numeric_locations(tmp_path: Path) -> None:
+    store = ParquetResultStore(tmp_path / "results")
+    store.write(_data(), fingerprint="fingerprint")
+
+    restored = store.read()
+
+    assert restored is not None
+    assert restored.components.data.columns.equals(_data().components.data.columns)
+    assert restored.components.data.index.equals(_data().components.data.index)
+    route = restored.routes[RouteIdentity("route-001", "Pressure")]
+    assert route.timeseries is not None
+    assert list(route.timeseries.columns.astype(float)) == [0.0, 10.0]
+    assert route.envelope is not None
+    assert list(route.envelope.index.astype(float)) == [0.0, 10.0]
+
+
+def test_empty_data_roundtrip(tmp_path: Path) -> None:
+    store = ParquetResultStore(tmp_path / "results")
+    store.write(ExtractedSimulationData(), fingerprint="fingerprint")
+
+    restored = store.read()
+
+    assert restored is not None
+    assert restored.components.data.empty
+    assert restored.routes == {}
+
+
+def test_payloads_are_owned_by_result_contracts() -> None:
+    frame = pd.DataFrame({"value": [1.0]})
+    components = ComponentTimeSeries(frame)
+    frame.loc[0, "value"] = 2.0
+
+    assert components.data.loc[0, "value"] == 1.0
+
+
+def test_corrupt_or_missing_marker_never_reads_as_complete(tmp_path: Path) -> None:
+    store = ParquetResultStore(tmp_path / "results")
+    store.write(_data(), fingerprint="fingerprint")
+    marker = tmp_path / "results" / "complete.json"
+
+    marker.unlink()
+    assert not store.is_complete()
+    assert store.read() is None
+
+    store.write(_data(), fingerprint="fingerprint")
+    marker.write_text('{"metadata_sha256":"wrong"}', encoding="utf-8")
+    assert not store.is_complete()
+
+
+def test_corrupt_result_file_never_reads_as_complete(tmp_path: Path) -> None:
+    store = ParquetResultStore(tmp_path / "results")
+    store.write(_data(), fingerprint="fingerprint")
+    (tmp_path / "results" / "components.parquet").write_bytes(b"corrupt")
+
+    assert not store.is_complete()
+    assert store.inventory() is None
+
+
+def test_interrupted_write_without_completion_marker_is_incomplete(tmp_path: Path) -> None:
+    store = ParquetResultStore(tmp_path / "results")
+    store.write(_data(), fingerprint="fingerprint")
+    (tmp_path / "results" / "complete.json").unlink()
+
+    assert store.read() is None
+
+
+def test_metadata_is_deterministic_and_uses_stable_route_identity(tmp_path: Path) -> None:
+    data = _data()
+    first = ParquetResultStore(tmp_path / "first")
+    second = ParquetResultStore(tmp_path / "second")
+    first.write(data, fingerprint="fingerprint")
+    second.write(data, fingerprint="fingerprint")
+
+    first_metadata = json.loads(
+        (tmp_path / "first" / "inventory.json").read_text(encoding="utf-8")
+    )
+    second_metadata = json.loads(
+        (tmp_path / "second" / "inventory.json").read_text(encoding="utf-8")
+    )
+
+    assert first_metadata == second_metadata
+    assert "title" not in json.dumps(first_metadata)
+    assert first_metadata["routes"][0]["route_id"] == "route-001"
+
+
+def test_results_package_does_not_import_forbidden_runtime_dependencies() -> None:
+    import pywandahydra.results  # noqa: F401
+
+    forbidden = {"pywanda", "matplotlib", "pywandahydra.execution", "pywandahydra.postprocessing"}
+    assert not forbidden.intersection(sys.modules)


### PR DESCRIPTION
Implements Slice 08 on top of the merged Slice 07 integration baseline.

Summary:
- add WANDA-free immutable result data contracts and stable component/route identities
- add explicit data requirements and inventory sufficiency checks
- add transactional `ParquetResultStore` with hash-validated completion markers
- preserve component MultiIndex and numeric-location fidelity
- add corruption, interruption, deterministic metadata, and import-boundary coverage

Validation:
- `uv run ruff check src/pywandahydra/results tests/unit_test/results`
- `uv run mypy src/pywandahydra/results`
- `uv run pytest -o addopts='' tests/unit_test/results/ -q` (10 passed)
- fresh-process import check confirms no `pywanda` or Matplotlib imports