### PR TITLE
refactor: add versioned run manifest API

### DIFF
--- a/src/pywandahydra/cli/commands.py
+++ b/src/pywandahydra/cli/commands.py
@@ -115,16 +115,16 @@ def validate(
     from ..run import validate_run
 
     try:
-        plan = validate_run(config)
+        report = validate_run(config)
     except (ValueError, FileNotFoundError) as e:
         typer.echo(f"Config INVALID: {e}", err=True)
         raise typer.Exit(code=1) from None
     typer.echo(
-        f"Config OK: run_id={plan.configuration.run_id}, "
-        f"workers={plan.configuration.execution.workers}"
+        f"Config OK: run_id={report.plan.configuration.run_id}, "
+        f"workers={report.plan.configuration.execution.workers}"
     )
     typer.echo(
-        f"Scenarios OK: {len(plan.scenario_document.scenarios)} total, {len(plan.cases)} included"
+        f"Scenarios OK: {len(report.plan.scenario_document.scenarios)} total, {len(report.plan.cases)} included"
     )
     typer.echo("Validation passed.")
 

--- a/src/pywandahydra/cli/commands.py
+++ b/src/pywandahydra/cli/commands.py
@@ -124,7 +124,8 @@ def validate(
         f"workers={report.plan.configuration.execution.workers}"
     )
     typer.echo(
-        f"Scenarios OK: {len(report.plan.scenario_document.scenarios)} total, {len(report.plan.cases)} included"
+        f"Scenarios OK: {len(report.plan.scenario_document.scenarios)} total,"
+        + f" {len(report.plan.cases)} included"
     )
     typer.echo("Validation passed.")
 

--- a/src/pywandahydra/execution/case_execution.py
+++ b/src/pywandahydra/execution/case_execution.py
@@ -152,7 +152,9 @@ def postprocess_case(
         with CaseLock(plan.case_dir), case_log_handler(plan.case_dir):
             current = status_store.read()
             simulation = (
-                current.simulation_fingerprint if current and current.simulation_fingerprint else simulation_identity(plan)
+                current.simulation_fingerprint
+                if current and current.simulation_fingerprint
+                else simulation_identity(plan)
             )
             status_store.write(
                 CaseStatus(

--- a/src/pywandahydra/execution/case_execution.py
+++ b/src/pywandahydra/execution/case_execution.py
@@ -147,11 +147,13 @@ def postprocess_case(
     """Process committed case data under its lock without opening WANDA."""
     started = time.perf_counter()
     status_store = CaseStatusStore(plan.case_dir)
-    simulation = simulation_identity(plan)
     output = output_identity(plan)
     try:
         with CaseLock(plan.case_dir), case_log_handler(plan.case_dir):
             current = status_store.read()
+            simulation = (
+                current.simulation_fingerprint if current and current.simulation_fingerprint else simulation_identity(plan)
+            )
             status_store.write(
                 CaseStatus(
                     case_id=plan.case_id,

--- a/src/pywandahydra/results/__init__.py
+++ b/src/pywandahydra/results/__init__.py
@@ -1,15 +1,5 @@
 """Durable, WANDA-free simulation result contracts and storage."""
 
-from .manifest import (
-    ManifestCorruptionError,
-    ManifestError,
-    ManifestVersionError,
-    RunManifest,
-    SourceFile,
-    read_manifest,
-    sha256_file,
-    write_manifest,
-)
 from .models import (
     ComponentIdentity,
     ComponentTimeSeries,

--- a/src/pywandahydra/results/__init__.py
+++ b/src/pywandahydra/results/__init__.py
@@ -1,5 +1,15 @@
 """Durable, WANDA-free simulation result contracts and storage."""
 
+from .manifest import (
+    ManifestCorruptionError,
+    ManifestError,
+    ManifestVersionError,
+    RunManifest,
+    SourceFile,
+    read_manifest,
+    sha256_file,
+    write_manifest,
+)
 from .models import (
     ComponentIdentity,
     ComponentTimeSeries,

--- a/src/pywandahydra/results/manifest.py
+++ b/src/pywandahydra/results/manifest.py
@@ -1,0 +1,161 @@
+"""Versioned, atomic run provenance manifests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import sys
+from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from ..config.models import RunConfiguration
+from ..scenarios.models.document import ScenarioDocument
+
+MANIFEST_FILENAME = "run_manifest.json"
+_SCHEMA_VERSION = 1
+
+
+class ManifestError(ValueError):
+    """Base error for invalid or unreadable run manifests."""
+
+
+class ManifestVersionError(ManifestError):
+    """Raised when a manifest uses a schema version this package cannot read."""
+
+
+class ManifestCorruptionError(ManifestError):
+    """Raised when a manifest is absent, malformed, or fails validation."""
+
+
+class SourceFile(BaseModel):
+    """Identity and hash of an authored input captured for a run."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str
+    sha256: str
+
+
+class RuntimeInfo(BaseModel):
+    """Versions available while the manifest was created."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    package_version: str
+    python_version: str
+    pywanda_version: str | None = None
+    wanda_version: str | None = None
+
+
+class RunManifest(BaseModel):
+    """The sole machine-readable source of run provenance and offline inputs."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    directory_schema_version: Literal[1] = 1
+    configuration: RunConfiguration
+    scenario_document: ScenarioDocument
+    run_dir: Path
+    created_at: str
+    invocation: tuple[str, ...] = ()
+    runtime: RuntimeInfo
+    sources: tuple[SourceFile, ...]
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        configuration: RunConfiguration,
+        scenario_document: ScenarioDocument,
+        run_dir: Path,
+        sources: tuple[SourceFile, ...],
+    ) -> RunManifest:
+        """Build a v1 manifest using only import-safe runtime provenance."""
+        return cls(
+            configuration=configuration,
+            scenario_document=scenario_document,
+            run_dir=run_dir,
+            created_at=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            invocation=tuple(sys.argv),
+            runtime=RuntimeInfo(
+                package_version=_package_version("pywanda-hydra"),
+                python_version=platform.python_version(),
+                pywanda_version=_optional_package_version("pywanda"),
+            ),
+            sources=sources,
+        )
+
+
+def manifest_path(run_dir: Path) -> Path:
+    """Return the canonical manifest path for a run directory."""
+    return run_dir / MANIFEST_FILENAME
+
+
+def sha256_file(path: Path) -> str:
+    """Calculate a stable SHA-256 digest for an authored input file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def write_manifest(manifest: RunManifest) -> Path:
+    """Atomically persist ``manifest`` as the run's sole metadata document."""
+    path = manifest_path(manifest.run_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(".json.tmp")
+    try:
+        with temporary.open("w", encoding="utf-8", newline="\n") as stream:
+            json.dump(
+                manifest.model_dump(mode="json"), stream, sort_keys=True, separators=(",", ":")
+            )
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise
+    return path
+
+
+def read_manifest(run_dir: Path) -> RunManifest:
+    """Read and validate a v1 manifest, rejecting unknown future versions."""
+    path = manifest_path(run_dir)
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ManifestCorruptionError(f"Missing run manifest: {path}") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ManifestCorruptionError(f"Corrupt run manifest at {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ManifestCorruptionError(f"Corrupt run manifest at {path}: root must be an object")
+    if value.get("schema_version") != _SCHEMA_VERSION:
+        raise ManifestVersionError(
+            f"unsupported manifest schema version {value.get('schema_version')!r} at {path}"
+        )
+    try:
+        return RunManifest.model_validate(value)
+    except ValidationError as exc:
+        raise ManifestCorruptionError(f"Corrupt run manifest at {path}: {exc}") from exc
+
+
+def _package_version(package: str) -> str:
+    try:
+        return version(package)
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _optional_package_version(package: str) -> str | None:
+    try:
+        return version(package)
+    except PackageNotFoundError:
+        return None

--- a/src/pywandahydra/run.py
+++ b/src/pywandahydra/run.py
@@ -16,8 +16,14 @@ from .execution.run_cases import run_cases
 from .execution.run_directory import case_data_directory
 from .execution.status import CaseStatus, CaseStatusStore
 from .postprocessing.pipeline import process_run_results
-from .results import ParquetResultStore, SourceFile, read_manifest, sha256_file, write_manifest
-from .results.manifest import RunManifest
+from .results import ParquetResultStore
+from .results.manifest import (
+    RunManifest,
+    SourceFile,
+    read_manifest,
+    sha256_file,
+    write_manifest,
+)
 from .scenarios import ScenarioSpecification
 from .scenarios.loader import load_scenario_document
 from .scenarios.models.document import ScenarioDocument

--- a/src/pywandahydra/run.py
+++ b/src/pywandahydra/run.py
@@ -1,18 +1,42 @@
-"""Public run preparation, validation, and execution API."""
+"""Public run preparation, validation, execution, and offline results API."""
 
 from __future__ import annotations
 
-import json
+import shutil
+from dataclasses import dataclass
 from pathlib import Path
 
 from .config import ExecutionConfiguration, RunConfiguration, load_run_config
+from .execution.case_execution import postprocess_case
 from .execution.locking import RunLock
 from .execution.outcomes import RunResult
-from .execution.plans import ModelSpecification, RunPlan, build_case_plans
+from .execution.plans import CasePlan, ModelSpecification, RunPlan, build_case_plans
+from .execution.result_extraction import requirements_from_scenario
 from .execution.run_cases import run_cases
+from .execution.run_directory import case_data_directory
+from .execution.status import CaseStatus, CaseStatusStore
 from .postprocessing.pipeline import process_run_results
+from .results import ParquetResultStore, SourceFile, read_manifest, sha256_file, write_manifest
+from .results.manifest import RunManifest
+from .scenarios import ScenarioSpecification
 from .scenarios.loader import load_scenario_document
 from .scenarios.models.document import ScenarioDocument
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationReport:
+    """Validated run inputs, including the side-effect-free execution plan."""
+
+    plan: RunPlan
+
+
+@dataclass(frozen=True, slots=True)
+class RunStatus:
+    """Offline view of one manifest and the current status of its cases."""
+
+    run_id: str
+    run_dir: Path
+    cases: tuple[CaseStatus | None, ...]
 
 
 def _resolve(path: Path, base_dir: Path) -> Path:
@@ -121,30 +145,40 @@ def _legacy_model_stub(
     )
 
 
-def validate_run(config_path: Path | str, *, preflight: bool = False) -> RunPlan:
+def validate_run(config_path: Path | str, *, preflight: bool = False) -> ValidationReport:
     """Validate and prepare a configuration, optionally checking WANDA inputs."""
-    return prepare_run(config_path, preflight=preflight)
+    return ValidationReport(prepare_run(config_path, preflight=preflight))
 
 
 def _prepare_run_directory(plan: RunPlan) -> None:
-    for name in ("figures", "logs", "tables", "scenarios"):
+    for name in ("figures", "inputs", "tables", "scenarios"):
         (plan.run_dir / name).mkdir(parents=True, exist_ok=True)
-    log_path = plan.run_dir / "logs" / "run.json"
-    log_path.write_text(
-        json.dumps(
-            {
-                "configuration": plan.configuration.model_dump(mode="json"),
-                "config_path": str(plan.config_path),
-                "scenarios": [
-                    scenario.model_dump(mode="json")
-                    for scenario in plan.scenario_document.scenarios
-                ],
-            },
-            indent=2,
-            default=str,
-        ),
-        encoding="utf-8",
+    sources = _copy_authored_inputs(plan)
+    write_manifest(
+        RunManifest.create(
+            configuration=plan.configuration,
+            scenario_document=plan.scenario_document,
+            run_dir=plan.run_dir,
+            sources=sources,
+        )
     )
+
+
+def _copy_authored_inputs(plan: RunPlan) -> tuple[SourceFile, ...]:
+    inputs = plan.run_dir / "inputs"
+    source_paths = (
+        ("configuration", plan.config_path),
+        ("scenarios", plan.scenario_document.source_path),
+        ("model", plan.model_path),
+    )
+    sources: list[SourceFile] = []
+    for category, source_path in source_paths:
+        name = f"{category}/{source_path.name}"
+        destination = inputs / name
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, destination)
+        sources.append(SourceFile(name=name, sha256=sha256_file(source_path)))
+    return tuple(sources)
 
 
 def execute_run(plan: RunPlan) -> RunResult:
@@ -161,3 +195,82 @@ def execute_run(plan: RunPlan) -> RunResult:
         cases=cases,
         post_processing=outcomes,
     )
+
+
+def read_run_status(run_dir: Path | str) -> RunStatus:
+    """Read one run's manifest and case statuses without opening WANDA."""
+    manifest = read_manifest(Path(run_dir))
+    statuses = tuple(
+        CaseStatusStore(manifest.run_dir / "scenarios" / scenario.name).read()
+        for scenario in manifest.scenario_document.scenarios
+        if scenario.include
+    )
+    return RunStatus(manifest.configuration.run_id, manifest.run_dir, statuses)
+
+
+def postprocess_run(
+    run_dir: Path | str, *, case_ids: set[str] | None = None
+) -> RunResult:
+    """Regenerate configured outputs from committed results without simulating."""
+    manifest = read_manifest(Path(run_dir))
+    selected = tuple(
+        scenario
+        for scenario in manifest.scenario_document.scenarios
+        if scenario.include and (case_ids is None or scenario.name in case_ids)
+    )
+    unknown = (case_ids or set()) - {scenario.name for scenario in selected}
+    if unknown:
+        raise ValueError(f"Unknown or excluded case IDs: {sorted(unknown)}")
+    plans = _offline_case_plans(manifest, selected)
+    _require_offline_stores(plans)
+    with RunLock(manifest.run_dir):
+        cases = tuple(postprocess_case(plan) for plan in plans)
+        outcomes = process_run_results(
+            run_root=manifest.run_dir,
+            run_id=manifest.configuration.run_id,
+        )
+    return RunResult(manifest.configuration.run_id, cases, outcomes)
+
+
+def _offline_model_specification(manifest: RunManifest) -> ModelSpecification:
+    """Build a placeholder model specification that offline post-processing never opens."""
+    return ModelSpecification(
+        model_path=manifest.run_dir / "inputs" / "model" / manifest.configuration.model.path.name,
+        wanda_bin=manifest.run_dir / "inputs",
+        base_model_name=manifest.configuration.model.path.stem,
+        upgrade=manifest.configuration.model.upgrade,
+        run_steady=manifest.configuration.simulation.steady,
+        run_unsteady=manifest.configuration.simulation.unsteady,
+    )
+
+
+def _offline_case_plans(
+    manifest: RunManifest, scenarios: tuple[ScenarioSpecification, ...]
+) -> tuple[CasePlan, ...]:
+    model_specification = _offline_model_specification(manifest)
+    return tuple(
+        CasePlan(
+            case_id=scenario.name,
+            case_dir=manifest.run_dir / "scenarios" / scenario.name,
+            model_spec=model_specification,
+            scenario=scenario,
+            analysis_metadata=manifest.scenario_document.analysis_metadata,
+            config_hash="manifest-v1",
+        )
+        for scenario in scenarios
+    )
+
+
+def _require_offline_stores(plans: tuple[CasePlan, ...]) -> None:
+    for plan in plans:
+        status = CaseStatusStore(plan.case_dir).read()
+        store = ParquetResultStore(case_data_directory(plan.case_dir))
+        if status is None or status.simulation_status != "succeeded":
+            raise ValueError(
+                f"Case {plan.case_id} has no successful simulation; resume or simulate it first."
+            )
+        inventory = store.inventory()
+        if inventory is None or not inventory.satisfies(requirements_from_scenario(plan.scenario)):
+            raise ValueError(
+                f"Case {plan.case_id} has incomplete result data; resume or simulate it first."
+            )

--- a/src/pywandahydra/run.py
+++ b/src/pywandahydra/run.py
@@ -17,13 +17,7 @@ from .execution.run_directory import case_data_directory
 from .execution.status import CaseStatus, CaseStatusStore
 from .postprocessing.pipeline import process_run_results
 from .results import ParquetResultStore
-from .results.manifest import (
-    RunManifest,
-    SourceFile,
-    read_manifest,
-    sha256_file,
-    write_manifest,
-)
+from .results.manifest import RunManifest, SourceFile, read_manifest, sha256_file, write_manifest
 from .scenarios import ScenarioSpecification
 from .scenarios.loader import load_scenario_document
 from .scenarios.models.document import ScenarioDocument
@@ -214,9 +208,7 @@ def read_run_status(run_dir: Path | str) -> RunStatus:
     return RunStatus(manifest.configuration.run_id, manifest.run_dir, statuses)
 
 
-def postprocess_run(
-    run_dir: Path | str, *, case_ids: set[str] | None = None
-) -> RunResult:
+def postprocess_run(run_dir: Path | str, *, case_ids: set[str] | None = None) -> RunResult:
     """Regenerate configured outputs from committed results without simulating."""
     manifest = read_manifest(Path(run_dir))
     selected = tuple(

--- a/src/pywandahydra/wanda/__init__.py
+++ b/src/pywandahydra/wanda/__init__.py
@@ -1,4 +1,22 @@
 """WANDA integration package interfaces."""
 
-from .model_access import WandaModelAccess  # noqa: F401
-from .session import wanda_session  # noqa: F401
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .model_access import WandaModelAccess
+
+if TYPE_CHECKING:
+    from .session import wanda_session
+
+
+def __getattr__(name: str) -> Any:
+    """Load the pywanda-backed session helper only when a caller requests it."""
+    if name == "wanda_session":
+        from .session import wanda_session
+
+        return wanda_session
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["WandaModelAccess", "wanda_session"]

--- a/tests/unit_test/results/test_manifest.py
+++ b/tests/unit_test/results/test_manifest.py
@@ -1,0 +1,72 @@
+"""Tests for versioned run manifest persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pywandahydra.config.models import (
+    ModelConfiguration,
+    RunConfiguration,
+)
+from pywandahydra.results.manifest import (
+    ManifestVersionError,
+    RunManifest,
+    SourceFile,
+    read_manifest,
+    sha256_file,
+    write_manifest,
+)
+from pywandahydra.scenarios import AnalysisMeta
+from pywandahydra.scenarios.models.document import ScenarioDocument
+
+
+def _manifest(tmp_path: Path) -> RunManifest:
+    source_path = tmp_path / "scenarios.xlsx"
+    source_path.write_bytes(b"scenario source")
+    configuration = RunConfiguration(
+        run_id="run_001",
+        output_root=tmp_path / "runs",
+        scenario_file=source_path,
+        model=ModelConfiguration(
+            path=tmp_path / "model.wdi",
+            wanda_bin=tmp_path / "wanda",
+        ),
+    )
+    document = ScenarioDocument(
+        analysis_metadata=AnalysisMeta(),
+        scenarios=(),
+        source_path=source_path,
+    )
+    return RunManifest.create(
+        configuration=configuration,
+        scenario_document=document,
+        run_dir=tmp_path / "runs" / "run_001",
+        sources=(SourceFile(name="scenarios.xlsx", sha256=sha256_file(source_path)),),
+    )
+
+
+def test_manifest_round_trip_is_atomic_and_preserves_source_hash(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+
+    write_manifest(manifest)
+
+    restored = read_manifest(manifest.run_dir)
+    assert restored == manifest
+    assert restored.sources[0].sha256 == sha256_file(tmp_path / "scenarios.xlsx")
+    assert not (manifest.run_dir / "run_manifest.json.tmp").exists()
+
+
+def test_manifest_rejects_unknown_schema_version(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    path = manifest.run_dir / "run_manifest.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps({**manifest.model_dump(mode="json"), "schema_version": 999}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ManifestVersionError, match="unsupported manifest schema version"):
+        read_manifest(manifest.run_dir)

--- a/tests/unit_test/results/test_manifest.py
+++ b/tests/unit_test/results/test_manifest.py
@@ -7,10 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from pywandahydra.config.models import (
-    ModelConfiguration,
-    RunConfiguration,
-)
+from pywandahydra.config.models import ModelConfiguration, RunConfiguration
 from pywandahydra.results.manifest import (
     ManifestVersionError,
     RunManifest,

--- a/tests/unit_test/test_cli_commands.py
+++ b/tests/unit_test/test_cli_commands.py
@@ -47,7 +47,9 @@ def test_validate_delegates_to_root_api(tmp_path: Path) -> None:
         cases=(object(),),
     )
 
-    with patch("pywandahydra.run.validate_run", return_value=plan) as validate:
+    with patch(
+        "pywandahydra.run.validate_run", return_value=SimpleNamespace(plan=plan)
+    ) as validate:
         invocation = runner.invoke(app, ["validate", str(config_path)])
 
     assert invocation.exit_code == 0

--- a/tests/unit_test/test_run_api.py
+++ b/tests/unit_test/test_run_api.py
@@ -8,8 +8,12 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from pywandahydra.results import SourceFile, sha256_file, write_manifest
-from pywandahydra.results.manifest import RunManifest
+from pywandahydra.results.manifest import (
+    RunManifest,
+    SourceFile,
+    sha256_file,
+    write_manifest,
+)
 from pywandahydra.run import (
     execute_run,
     postprocess_run,

--- a/tests/unit_test/test_run_api.py
+++ b/tests/unit_test/test_run_api.py
@@ -8,12 +8,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from pywandahydra.results.manifest import (
-    RunManifest,
-    SourceFile,
-    sha256_file,
-    write_manifest,
-)
+from pywandahydra.results.manifest import RunManifest, SourceFile, sha256_file, write_manifest
 from pywandahydra.run import (
     execute_run,
     postprocess_run,

--- a/tests/unit_test/test_run_api.py
+++ b/tests/unit_test/test_run_api.py
@@ -3,14 +3,22 @@
 from __future__ import annotations
 
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 import yaml
 
-from pywandahydra.run import execute_run, prepare_run, validate_run
+from pywandahydra.results import SourceFile, sha256_file, write_manifest
+from pywandahydra.results.manifest import RunManifest
+from pywandahydra.run import (
+    execute_run,
+    postprocess_run,
+    prepare_run,
+    read_run_status,
+    validate_run,
+)
 from pywandahydra.scenarios import AnalysisMeta, ScenarioSpecification
+from pywandahydra.scenarios.models.document import ScenarioDocument
 
 
 def _write_configuration(tmp_path: Path) -> Path:
@@ -35,12 +43,16 @@ def _write_configuration(tmp_path: Path) -> Path:
     return path
 
 
-def _document(path: Path, *names: str) -> SimpleNamespace:
+def _document(path: Path, *names: str) -> ScenarioDocument:
     scenarios = tuple(
         ScenarioSpecification(number=index, include=True, name=name)
         for index, name in enumerate(names, 1)
     )
-    return SimpleNamespace(scenarios=scenarios, analysis_metadata=AnalysisMeta(), source_path=path)
+    return ScenarioDocument(
+        scenarios=scenarios,
+        analysis_metadata=AnalysisMeta(),
+        source_path=path,
+    )
 
 
 def test_prepare_run_resolves_paths_without_writing(tmp_path: Path) -> None:
@@ -96,4 +108,26 @@ def test_execute_run_dispatches_prepared_cases_and_aggregate_outputs(tmp_path: P
     assert result.cases == expected_cases
     assert result.post_processing == expected_outputs
     assert run_cases.call_args.args == (plan.cases, 1)
-    assert (plan.run_dir / "logs" / "run.json").is_file()
+    assert (plan.run_dir / "run_manifest.json").is_file()
+    assert not (plan.run_dir / "logs" / "run.json").exists()
+
+
+def test_offline_postprocessing_requires_committed_simulation_data(tmp_path: Path) -> None:
+    path = _write_configuration(tmp_path)
+    document = _document(tmp_path / "scenarios.xlsx", "case_one")
+    with patch("pywandahydra.run.load_scenario_document", return_value=document):
+        plan = prepare_run(path)
+    write_manifest(
+        RunManifest.create(
+            configuration=plan.configuration,
+            scenario_document=document,
+            run_dir=plan.run_dir,
+            sources=(SourceFile(name="configuration/run.yaml", sha256=sha256_file(path)),),
+        )
+    )
+
+    status = read_run_status(plan.run_dir)
+    assert status.run_id == "run_001"
+    assert status.cases == (None,)
+    with pytest.raises(ValueError, match="resume or simulate it first"):
+        postprocess_run(plan.run_dir)


### PR DESCRIPTION
## Summary
- add an atomic, versioned `run_manifest.json` as the run provenance source, including resolved configuration, scenario document, runtime provenance, and source hashes
- copy authored configuration, scenario, and model inputs under `inputs/`; remove legacy `logs/run.json` output
- complete WANDA-free `read_run_status` and `postprocess_run` root APIs, with explicit errors for absent or incomplete stores
- make the WANDA session import lazy so offline root APIs do not import `pywanda`

## Validation
- `.venv\Scripts\python.exe -m pytest -o addopts='' tests/unit_test/results/test_manifest.py tests/unit_test/test_run_api.py -q` (7 passed)
- `.venv\Scripts\ruff.exe check .\src\pywandahydra\run.py .\src\pywandahydra\results .\src\pywandahydra\wanda\__init__.py .\tests\unit_test\results\test_manifest.py .\tests\unit_test\test_run_api.py`
- `.venv\Scripts\mypy.exe src/pywandahydra/run.py src/pywandahydra/results src/pywandahydra/wanda/__init__.py`
- fresh-process import boundary: `from pywandahydra.run import read_run_status, postprocess_run` leaves `pywanda` unloaded
- `git diff --check`

## Notes
The configured real-WANDA resume/offline end-to-end integration test was not run in this slice; focused unit coverage validates manifest round trips/version rejection and refusal to simulate when result stores are absent.